### PR TITLE
Improve dependency checking

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,5 @@
+[report]
+# Glob pattern(s) of files to omit from the report.
+omit =
+    */devops/compose/*
+    */helpers/test/outcomes/*/tmp.scratch/*

--- a/.github/gh_requirements.txt
+++ b/.github/gh_requirements.txt
@@ -1,4 +1,5 @@
-invoke
-tqdm
-s3fs
 boto3 >= 1.20.17
+coverage
+invoke
+s3fs
+tqdm

--- a/.github/workflows/coverage_tests.yml
+++ b/.github/workflows/coverage_tests.yml
@@ -1,0 +1,173 @@
+name: Test coverage
+
+on:
+  workflow_dispatch: {}
+  # every day at 00:00 UTC.
+  schedule:
+    - cron: '0 0 * * *'
+
+env:
+  CSFY_CI: true
+
+permissions:
+  # Required to authenticate and retrieve temporary AWS credentials via OIDC.
+  id-token: write
+  # Required to fetch and check out code from the repository.
+  contents: read
+  # Required to authenticate and pull Docker images from GitHub Container Registry (GHCR).
+  packages: read
+
+
+jobs:
+  run_test_coverage:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: ${{ vars.GH_ACTION_AWS_ROLE_ARN }}
+          role-session-name: ${{ vars.GH_ACTION_AWS_SESSION_NAME }}
+          aws-region: ${{ vars.CSFY_AWS_DEFAULT_REGION }}
+
+      - name: Login to GHCR
+        run: docker login ghcr.io -u gpsaggese -p ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Cleanup
+        run: sudo chmod 777 -R .
+
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          submodules: recursive
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Update PYTHONPATH
+        run: echo "PYTHONPATH=.:helpers" >> $GITHUB_ENV
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r .github/gh_requirements.txt
+
+      - name: Pull image from GHCR
+        run: docker pull ghcr.io/${{ github.repository }}:dev
+
+      # Only on scheduled runs, capture ISO weekday (1=Mon … 7=Sun).
+      - name: Set DAY_OF_WEEK
+        if: github.event_name == 'schedule'
+        run: echo "DAY_OF_WEEK=$(date -u +'%u')" >> $GITHUB_ENV
+
+      # This step is used to trigger the fast test coverage generation using the invoke task.
+      - name: Run Fast test and generate report
+        id: run_fast
+        continue-on-error: true
+        run: |
+          echo "Simulating fast test failure"
+          exit 1
+        # env:
+        #   GH_ACTION_ACCESS_TOKEN: ${{ secrets.GH_ACTION_ACCESS_TOKEN }}
+        #   CSFY_AWS_ACCESS_KEY_ID: ${{ env.AWS_ACCESS_KEY_ID }}
+        #   CSFY_AWS_SECRET_ACCESS_KEY: ${{ env.AWS_SECRET_ACCESS_KEY }}
+        #   CSFY_AWS_SESSION_TOKEN: ${{ env.AWS_SESSION_TOKEN }}
+        #   CSFY_AWS_DEFAULT_REGION: ${{ env.AWS_DEFAULT_REGION }}
+        #   CSFY_ECR_BASE_PATH: ghcr.io/${{ github.repository_owner }}
+        #   CSFY_AWS_S3_BUCKET: ${{ vars.CSFY_AWS_S3_BUCKET }}
+        # run: invoke run_coverage --suite fast
+
+      - name: Upload Fast Test Coverage to Codecov
+        id: upload_fast
+        # Only upload if the previous fast test run step succeeded (i.r report generated).
+        # failed step don’t generate a coverage report, so there's nothing to upload.
+        if: steps.run_fast.outcome == 'success'
+        continue-on-error: true
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./coverage.xml
+          # Specify the Codecov flag name associated with this test suite.
+          # Required to separate coverage reports by type (e.g., fast, slow, superslow) inside the Codecov UI.
+          flags: fast
+          name: fast-test-coverage
+
+      - name: Run Slow test and generate report
+        id: run_slow
+        continue-on-error: true
+        env:
+          GH_ACTION_ACCESS_TOKEN: ${{ secrets.GH_ACTION_ACCESS_TOKEN }}
+          CSFY_AWS_ACCESS_KEY_ID: ${{ env.AWS_ACCESS_KEY_ID }}
+          CSFY_AWS_SECRET_ACCESS_KEY: ${{ env.AWS_SECRET_ACCESS_KEY }}
+          CSFY_AWS_SESSION_TOKEN: ${{ env.AWS_SESSION_TOKEN }}
+          CSFY_AWS_DEFAULT_REGION: ${{ env.AWS_DEFAULT_REGION }}
+          CSFY_ECR_BASE_PATH: ghcr.io/${{ github.repository_owner }}
+          CSFY_AWS_S3_BUCKET: ${{ vars.CSFY_AWS_S3_BUCKET }}
+        run: invoke run_coverage --suite slow
+
+      - name: Upload Slow Test Coverage to Codecov
+        id: upload_slow
+        # Only upload if the previous slow test run step succeeded (i.r report generated).
+        if: steps.run_slow.outcome == 'success'
+        continue-on-error: true
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./coverage.xml
+          flags: slow
+          name: slow-test-coverage
+
+      - name: Run Superslow test and generate report
+        # Run only on scheduled jobs or manual trigger
+        if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+        env:
+          GH_ACTION_ACCESS_TOKEN: ${{ secrets.GH_ACTION_ACCESS_TOKEN }}
+          CSFY_AWS_ACCESS_KEY_ID: ${{ env.AWS_ACCESS_KEY_ID }}
+          CSFY_AWS_SECRET_ACCESS_KEY: ${{ env.AWS_SECRET_ACCESS_KEY }}
+          CSFY_AWS_SESSION_TOKEN: ${{ env.AWS_SESSION_TOKEN }}
+          CSFY_AWS_DEFAULT_REGION: ${{ env.AWS_DEFAULT_REGION }}
+          CSFY_ECR_BASE_PATH: ghcr.io/${{ github.repository_owner }}
+          CSFY_AWS_S3_BUCKET: ${{ vars.CSFY_AWS_S3_BUCKET }}
+        run: |
+          # Only run superslow tests if it's Monday or a manual dispatch.
+          day_of_week=$(date +%u)
+          if [ "$day_of_week" = "1" ] || [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            invoke run_coverage --suite superslow
+          else
+            echo "Skipping superslow tests — not Monday and not manually triggered"
+            exit 0
+          fi
+
+      - name: Upload Superslow Test Coverage to Codecov
+        #TODO(Shaunak): Consider removing it when we turn this workflow into a reusable one.
+        if: steps.run_superslow.outcome == 'success'
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./coverage.xml
+          flags: superslow
+          name: superslow-test-coverage
+
+        # Fail the job in CI if any of the fast/ slow run/ upload steps above failed.
+      - name: Fail if fast/slow test or upload failed
+        run: |
+          failed=""
+          if [ "${{ steps.run_fast.outcome }}" != "success" ]; then
+            echo "Fast test run failed"
+            failed="true"
+          fi
+          if [ "${{ steps.upload_fast.outcome }}" != "success" ]; then
+            echo "Fast test coverage upload failed"
+            failed="true"
+          fi
+          if [ "${{ steps.run_slow.outcome }}" != "success" ]; then
+            echo "Slow test run failed"
+            failed="true"
+          fi
+          if [ "${{ steps.upload_slow.outcome }}" != "success" ]; then
+            echo "Slow test coverage upload failed"
+            failed="true"
+          fi
+          if [ "$failed" = "true" ]; then
+            echo "At least one fast/slow test or upload step failed."
+            exit 1
+          fi

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,14 @@
 __pycache__/
 *.log
 tmp.requirements.txt
+helpers.egg-info/PKG-INFO
+helpers.egg-info/SOURCES.txt
+helpers.egg-info/top_level.txt
+.coverage
+.DS_Store
+dependency_graph.dot
+dependency_graph.svg
+report.txt
+report_cycles.txt
+report_max_level.txt
+i

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.log
+tmp.requirements.txt

--- a/conftest.py
+++ b/conftest.py
@@ -7,21 +7,22 @@ import helpers.hunit_test as hut
 
 # Hack to workaround pytest not happy with multiple redundant conftest.py
 # (bug #34).
-if not hasattr(hut, "_CONFTEST_ALREADY_PARSED"):
+#if not hasattr(hut, "_CONFTEST_ALREADY_PARSED"):
     # import helpers.hversion as hversi
     # hversi.check_version()
 
     # pylint: disable=protected-access
-    hut._CONFTEST_ALREADY_PARSED = True
+    #hut._CONFTEST_ALREADY_PARSED = True
 
     # Store whether we are running unit test through pytest.
     # pylint: disable=line-too-long
     # From https://docs.pytest.org/en/latest/example/simple.html#detect-if-running-from-within-a-pytest-run
-    def pytest_configure(config: Any) -> None:
-        _ = config
-        # pylint: disable=protected-access
-        hut._CONFTEST_IN_PYTEST = True
 
+def pytest_configure(config: Any) -> None:
+    _ = config
+    # pylint: disable=protected-access
+    hut._CONFTEST_IN_PYTEST = True
+    
     def pytest_unconfigure(config: Any) -> None:
         _ = config
         # pylint: disable=protected-access

--- a/dev_scripts_helpers/chatgpt/run_simple_chatgpt.py
+++ b/dev_scripts_helpers/chatgpt/run_simple_chatgpt.py
@@ -4,24 +4,17 @@ import argparse
 import logging
 import os
 
-from openai import OpenAI
-
 import helpers.hchatgpt_instructions as hchainst
 import helpers.hdbg as hdbg
+import helpers.henv as henv
 import helpers.hparser as hparser
 
-_LOG = logging.getLogger(__name__)
-
-try:
-    pass
-except ImportError:
-    os.system("pip install openai")
-finally:
-    pass
+henv.install_module_if_not_present("openai")
+import openai
 
 _LOG = logging.getLogger(__name__)
 
-client = OpenAI(
+client = openai.OpenAI(
     # This is the default and can be omitted
     api_key=os.environ.get("OPENAI_API_KEY"),
 )
@@ -39,7 +32,7 @@ def _process_text(txt: str, instruction: str) -> str:
             {
                 "role": "user",
                 "content": txt,
-            }
+            },
         ],
         model="gpt-3.5-turbo",
     )

--- a/dev_scripts_helpers/chatgpt/run_simple_chatgpt.py
+++ b/dev_scripts_helpers/chatgpt/run_simple_chatgpt.py
@@ -54,8 +54,7 @@ def _parse() -> argparse.ArgumentParser:
 
 def _main(parser: argparse.ArgumentParser) -> None:
     args = parser.parse_args()
-    print("cmd line: %s" % hdbg.get_command_line())
-    hdbg.init_logger(verbosity=args.log_level, use_exec_path=True)
+    hparser.init_logger_for_input_output_transform(args)
     #
     in_file_name, out_file_name = hparser.parse_input_output_args(
         args, clear_screen=True

--- a/dev_scripts_helpers/coding_tools/traceback_to_cfile.py
+++ b/dev_scripts_helpers/coding_tools/traceback_to_cfile.py
@@ -56,7 +56,7 @@ def _parse() -> argparse.ArgumentParser:
 
 def _main(parser: argparse.ArgumentParser) -> None:
     args = parser.parse_args()
-    hdbg.init_logger(verbosity=args.log_level, use_exec_path=False)
+    hparser.init_logger_for_input_output_transform(args)
     # Parse files.
     in_file_name, out_file_name = hparser.parse_input_output_args(
         args, clear_screen=True

--- a/dev_scripts_helpers/coding_tools/transform_skeleton.py
+++ b/dev_scripts_helpers/coding_tools/transform_skeleton.py
@@ -34,8 +34,7 @@ def _parse() -> argparse.ArgumentParser:
 
 def _main(parser: argparse.ArgumentParser) -> None:
     args = parser.parse_args()
-    print("cmd line: %s" % hdbg.get_command_line())
-    hdbg.init_logger(verbosity=args.log_level, use_exec_path=True)
+    hparser.init_logger_for_input_output_transform(args)
     # Parse files.
     in_file_name, out_file_name = hparser.parse_input_output_args(args)
     _ = in_file_name, out_file_name

--- a/dev_scripts_helpers/documentation/dockerized_prettier.py
+++ b/dev_scripts_helpers/documentation/dockerized_prettier.py
@@ -54,14 +54,12 @@ def _parse() -> argparse.ArgumentParser:
 def _main(parser: argparse.ArgumentParser) -> None:
     # Parse everything that can be parsed and returns the rest.
     args, cmd_opts = parser.parse_known_args()
+    hparser.init_logger_for_input_output_transform(args)
     in_file_name, out_file_name = hparser.parse_input_output_args(
         args, clear_screen=True
     )
     if not cmd_opts:
         cmd_opts = []
-    hdbg.init_logger(
-        verbosity=args.log_level, use_exec_path=True, force_white=False
-    )
     _LOG.debug("cmd_opts: %s", cmd_opts)
     hdocker.run_dockerized_prettier(
         in_file_name,

--- a/dev_scripts_helpers/documentation/extract_headers_from_markdown.py
+++ b/dev_scripts_helpers/documentation/extract_headers_from_markdown.py
@@ -85,9 +85,7 @@ def _parse() -> argparse.ArgumentParser:
 
 def _main(parser: argparse.ArgumentParser) -> None:
     args = parser.parse_args()
-    hdbg.init_logger(
-        verbosity=args.log_level, use_exec_path=True, force_white=False
-    )
+    hparser.init_logger_for_input_output_transform(args)
     in_file_name, out_file_name = hparser.parse_input_output_args(args)
     #
     _extract_headers_from_markdown(

--- a/dev_scripts_helpers/documentation/lint_notes.py
+++ b/dev_scripts_helpers/documentation/lint_notes.py
@@ -94,6 +94,7 @@ def _preprocess(txt: str) -> str:
     return txt_new_as_str
 
 
+# TODO(gp): Move this somewhere else.
 # TODO(gp): Remove the code path using non dockerized executable, after fix for
 # CmampTask10710.
 def prettier(
@@ -102,6 +103,7 @@ def prettier(
     *,
     print_width: int = 80,
     use_dockerized_prettier: bool = True,
+    # TODO(gp): Remove this.
     **kwargs: Any,
 ) -> None:
     """
@@ -258,6 +260,7 @@ def _refresh_toc(
     txt: str,
     *,
     use_dockerized_markdown_toc: bool = True,
+    # TODO(gp): Remove this.
     **kwargs: Any,
 ) -> str:
     """

--- a/dev_scripts_helpers/documentation/notes_to_pdf.py
+++ b/dev_scripts_helpers/documentation/notes_to_pdf.py
@@ -133,7 +133,7 @@ def _filter_by_lines(file_name: str, filter_by_lines: str, prefix: str) -> str:
     # E.g., filter_by_lines='1:10'.
     m = re.match(r"^(\S+):(\S+)$", filter_by_lines)
     hdbg.dassert(m, "Invalid filter_by_lines='%s'", filter_by_lines)
-    start_line, end_line = m.group(1), m.group(2)
+    start_line, end_line = m.groups()
     if start_line.lower() == "none":
         start_line = 1
     else:
@@ -206,6 +206,7 @@ def _render_images(file_name: str, prefix: str) -> str:
     out = "\n".join(out)
     file3 = f"{prefix}.render_image2.txt"
     hio.to_file(file3, out)
+    _LOG.info("Remove commented code and saved file='%s'", file3)
     #
     file_out = file3
     return file_out
@@ -299,7 +300,7 @@ def _run_pandoc_to_pdf(
         "latex_abbrevs.sty",
     )
     hdbg.dassert_file_exists(latex_file)
-    #cmd = f"cp -f {latex_file} ."
+    # cmd = f"cp -f {latex_file} ."
     cmd = f"cp -f {latex_file} {out_dir}"
     _ = _system(cmd)
     #
@@ -326,7 +327,7 @@ def _run_pandoc_to_pdf(
     else:
         _LOG.warning("Skipping: run latex again")
     # Remove `latex_abbrevs.sty`.
-    #os.remove("latex_abbrevs.sty")
+    # os.remove("latex_abbrevs.sty")
     # Get the path of the output file created by Latex.
     file_out = os.path.basename(file_name).replace(".tex", ".pdf")
     file_out = os.path.join(out_dir, file_out)

--- a/dev_scripts_helpers/documentation/render_images.py
+++ b/dev_scripts_helpers/documentation/render_images.py
@@ -564,7 +564,7 @@ def _parse() -> argparse.ArgumentParser:
 
 def _main(parser: argparse.ArgumentParser) -> None:
     args = parser.parse_args()
-    hdbg.init_logger(verbosity=args.log_level, use_exec_path=True)
+    hparser.init_logger_for_input_output_transform(args)
     # Get the paths to the input and output files.
     in_file, out_file = hparser.parse_input_output_args(args)
     # Verify that the input and output file types are valid and equal.

--- a/dev_scripts_helpers/documentation/transform_notes.py
+++ b/dev_scripts_helpers/documentation/transform_notes.py
@@ -31,6 +31,7 @@ import argparse
 import hashlib
 import logging
 
+import dev_scripts_helpers.documentation.lint_notes as dshdlino
 import helpers.hdbg as hdbg
 import helpers.hlatex as hlatex
 import helpers.hmarkdown as hmarkdo
@@ -52,9 +53,7 @@ def _parse() -> argparse.ArgumentParser:
 
 def _main(parser: argparse.ArgumentParser) -> None:
     args = parser.parse_args()
-    hdbg.init_logger(
-        verbosity=logging.ERROR, use_exec_path=True, force_white=False
-    )
+    hparser.init_logger_for_input_output_transform(args)
     #
     cmd = args.action
     max_lev = int(args.max_lev)
@@ -91,15 +90,16 @@ def _main(parser: argparse.ArgumentParser) -> None:
         txt = "\n".join(txt)
         txt = hmarkdo.remove_formatting(txt)
         hparser.write_file(txt, out_file_name)
-    elif cmd == "md_fix_chatgpt_output":
-        txt = hparser.read_file(in_file_name)
-        txt = "\n".join(txt)
-        txt = hmarkdo.fix_chatgpt_output(txt)
-        hparser.write_file(txt, out_file_name)
     elif cmd == "md_clean_up":
         txt = hparser.read_file(in_file_name)
         txt = "\n".join(txt)
         txt = hmarkdo.md_clean_up(txt)
+        txt = dshdlino.prettier_on_str(txt)
+        hparser.write_file(txt, out_file_name)
+    elif cmd == "md_format":
+        txt = hparser.read_file(in_file_name)
+        txt = "\n".join(txt)
+        txt = dshdlino.prettier_on_str(txt)
         hparser.write_file(txt, out_file_name)
     else:
         assert 0, f"Invalid cmd='{cmd}'"

--- a/dev_scripts_helpers/git/git_hooks/install_hooks.py
+++ b/dev_scripts_helpers/git/git_hooks/install_hooks.py
@@ -49,12 +49,9 @@ def _main() -> None:
     #
     args = parser.parse_args()
     hdbg.init_logger(verbosity=args.log_level)
-    # Get amp dir.
-    amp_dir = hgit.get_amp_abs_path()
-    _LOG.info("amp_dir=%s", amp_dir)
-    hdbg.dassert_dir_exists(amp_dir)
     # Get the dir with the Git hooks to install.
-    src_dir = os.path.join(amp_dir, "dev_scripts_helpers/git/git_hooks")
+    helpers_root = hgit.find_helpers_root()
+    src_dir = os.path.join(helpers_root, "dev_scripts_helpers/git/git_hooks")
     _LOG.info("src_dir=%s", src_dir)
     hdbg.dassert_dir_exists(src_dir)
     # Find the location to install the Git hooks.

--- a/dev_scripts_helpers/git/git_hooks/pre-commit.py
+++ b/dev_scripts_helpers/git/git_hooks/pre-commit.py
@@ -61,13 +61,8 @@ if __name__ == "__main__":
     dshgghout.check_python_compile()
     lines.append("- 'check_python_compile' passed")
     assert os.path.exists(".git")
-    if os.path.isdir(".git"):
-        dshgghout.check_gitleaks()
-        lines.append("- 'check_gitleaks' passed")
-    else:
-        # TODO(gp): Fix HelpersTask622.
-        _LOG.warning("Skipping 'check_gitleaks' since we are in a submodule")
-        lines.append("- 'check_gitleaks' skipped")
+    dshgghout.check_gitleaks()
+    lines.append("- 'check_gitleaks' passed")
     print(
         "\n"
         + dshgghout.color_highlight(

--- a/dev_scripts_helpers/git/git_hooks/utils.py
+++ b/dev_scripts_helpers/git/git_hooks/utils.py
@@ -469,11 +469,14 @@ def check_python_compile(
 
 def get_git_root_dir() -> str:
     """
-    Return path to the root of the git repository.
+    Return the absolute path to the outermost Git repository root.
 
-    :return: absolute path to the root of the git repository
+    If inside a Git submodule, this returns the parent (superproject)
+    root. Otherwise, it returns the current repository's root.
+
+    :return: absolute path to the outermost Git repository root
     """
-    cmd = "git rev-parse --show-toplevel"
+    cmd = "git rev-parse --show-superproject-working-tree --show-toplevel | head -n1"
     _, git_root_dir = _system_to_string(cmd)
     git_root_dir = git_root_dir.strip()
     return git_root_dir

--- a/dev_scripts_helpers/git/git_hooks/utils.py
+++ b/dev_scripts_helpers/git/git_hooks/utils.py
@@ -216,7 +216,7 @@ def check_author(abort_on_error: bool = True) -> None:
     user_email = user_email.lstrip().rstrip()
     cmd = f"{_GIT_BINARY_PATH} config --show-origin {var}"
     _system_to_string(cmd, verbose=verbose)
-    print(f"user_email='{user_email}")
+    print(f"user_email='{user_email}'")
     # Check.
     error = False
     if not user_email.endswith("@gmail.com"):
@@ -356,7 +356,8 @@ def _check_words_in_text(
             val = m.group(1)
             _LOG.debug("  -> found '%s'", val)
             val = caesar(val, _CAESAR_STEP)
-            violation = f"{file_name}:{i+1}: Found '{val}'"
+            i_tmp = i + 1
+            violation = f"{file_name}:{i_tmp}: Found '{val}'"
             violations.append(violation)
     return violations
 
@@ -488,7 +489,6 @@ def check_gitleaks(abort_on_error: bool = True) -> None:
     """
     func_name = _report()
     git_root_dir = get_git_root_dir()
-    # > docker run -v /data/heanhs/src/helpers2:/app zricethezav/gitleaks:latest -c /app/.github/gitleaks-rules.toml git /app --pre-commit --staged
     cmd = f"""
     docker run -v {git_root_dir}:/app zricethezav/gitleaks:latest -c /app/.github/gitleaks-rules.toml git /app --pre-commit --staged --verbose
     """

--- a/dev_scripts_helpers/llms/dockerized_llm_apply_cfile.py
+++ b/dev_scripts_helpers/llms/dockerized_llm_apply_cfile.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+
+"""
+Run a transformation script using LLMs. It requires certain dependencies to be
+present (e.g., `openai`) and thus it is executed within a Docker container.
+
+To use this script, you need to provide the input file, output file, and
+the type of transformation to apply.
+"""
+
+import argparse
+import logging
+import re
+from typing import List, Tuple
+
+import tqdm
+
+import dev_scripts_helpers.llms.llm_prompts as dshlllpr
+import helpers.hdbg as hdbg
+import helpers.hio as hio
+import helpers.hparser as hparser
+import helpers.hsystem as hsystem
+
+_LOG = logging.getLogger(__name__)
+
+
+def _parse_cfile(cfile: str) -> List[Tuple[str, str, str]]:
+    """
+    Read and parse a cfile.
+
+    :param cfile: path to the cfile
+    :return: list of tuples, each containing a line number and a transform, e.g.,
+        [(file_name, line_number, transform), ...]
+    """
+    # Read the cfile.
+    cfile_lines = hio.from_file(cfile)
+    cfile_lines = cfile_lines.split("\n")
+    #
+    ret = []
+    # Parse the cfile.
+    for line in cfile_lines:
+        _LOG.debug("line=%s", line)
+        hdbg.dassert_isinstance(line, str)
+        # Parse the lines of the cfile, like
+        # ```
+        # dev_scripts_helpers/llms/llm_prompts.py:106: in public function `test`:D404: ...
+        # dev_scripts_helpers/llms/llm_prompts.py:110: error: Need type annotation for ...
+        # ```
+        # extracting the file name, line number, and transform.
+        regex = r"^(.+):(\d+): (.*)$"
+        match = re.match(regex, line)
+        if match is None:
+            _LOG.debug("Failed to parse line '%s'", line)
+            continue
+        # Extract the file name, line number, and transform.
+        file_name = match.group(1)
+        line_number = match.group(2)
+        transform = match.group(3)
+        # Add values to the list.
+        ret.append((file_name, line_number, transform))
+    return ret
+
+
+def _apply_transforms(
+    cfile_lines: List[Tuple[str, str, str]], prompt_tag: str, model: str
+) -> None:
+    """
+    Apply the transforms to the file.
+
+    :param cfile_lines: list of tuples, each containing a file name,
+        line number, and transform
+    :param model: model to use for the transformation
+    """
+    # Create a dict from file to line number to transform.
+    file_to_line_to_transform: Dict[str, Tuple[int, str]] = {}
+    for file_name, line_number, transform in cfile_lines:
+        if file_name not in file_to_line_to_transform:
+            file_to_line_to_transform[file_name] = []
+        file_to_line_to_transform[file_name].append((line_number, transform))
+    #
+    _LOG.info("Files to transform: %s", len(file_to_line_to_transform.keys()))
+    _LOG.info("Total number of transform: %s", len(cfile_lines))
+    # Apply the transforms to the file.
+    for file_name, line_to_transform in tqdm.tqdm(
+        file_to_line_to_transform.items()
+    ):
+        _LOG.info("Applying transforms to file '%s'", file_name)
+        # Look for file in the current directory.
+        cmd = f'find -path "*/{file_name}"'
+        _, act_file_name = hsystem.system_to_one_line(cmd)
+        _LOG.debug("Found file '%s' -> '%s'", file_name, act_file_name)
+        # Read the file.
+        hdbg.dassert_path_exists(act_file_name)
+        txt_in = hio.from_file(act_file_name)
+        # Prepare the instructions for the prompt.
+        instructions = "\n".join(
+            [
+                f"{line_number}: {transform}"
+                for line_number, transform in line_to_transform
+            ]
+        )
+        # Transform the file using the instructions.
+        txt_out = dshlllpr.run_prompt(
+            prompt_tag,
+            txt_in,
+            model,
+            instructions=instructions,
+            in_file_name="",
+            out_file_name="",
+        )
+        # Write the file.
+        hio.to_file(act_file_name, txt_out)
+
+
+# # TODO(gp): This should become an invoke or a command, where we read a file
+# and a cfile and inject TODOs in the code.
+# def _annotate_with_cfile(txt: str, txt_cfile: str) -> str:
+#     """
+#     Annotate a file `txt` with TODOs from the cfile `txt_cfile`.
+#     """
+#     ret_out = _extract_vim_cfile_lines(txt_cfile)
+#     # Convert ret_out to a dict.
+#     ret_out_dict = {}
+#     for line_number, line in ret_out:
+#         if line_number not in ret_out_dict:
+#             ret_out_dict[line_number] = [line]
+#         else:
+#             ret_out_dict[line_number].append(line)
+#     # Annotate the code.
+#     txt_out = []
+#     for line_number, line in txt:
+#         if line_number in ret_out_dict:
+#             for todo in ret_out_dict[line_number]:
+#                 txt_out.append(f"# TODO(*): {todo}")
+#         else:
+#             txt_out.append(line)
+#     return "\n".join(txt_out)
+
+
+# #############################################################################
+
+
+def _parse() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "--cfile",
+        type=str,
+        required=True,
+        help="Path to the cfile",
+    )
+    hparser.add_prompt_arg(parser)
+    hparser.add_verbosity_arg(parser, log_level="CRITICAL")
+    return parser
+
+
+def _main(parser: argparse.ArgumentParser) -> None:
+    args = parser.parse_args()
+    hdbg.init_logger(verbosity=args.log_level, use_exec_path=True)
+    # TODO(gp): Factor this out.
+    if args.fast_model:
+        model = "gpt-4o-mini"
+    else:
+        model = "gpt-4o"
+    # Apply the transforms.
+    cfile_lines = _parse_cfile(args.cfile)
+    _apply_transforms(cfile_lines, args.prompt, model)
+
+
+if __name__ == "__main__":
+    _main(_parse())

--- a/dev_scripts_helpers/llms/dockerized_llm_transform.py
+++ b/dev_scripts_helpers/llms/dockerized_llm_transform.py
@@ -1,9 +1,8 @@
 #!/usr/bin/env python3
 
 """
-This script is designed to run a transformation script using LLMs. It requires
-certain dependencies to be present (e.g., `openai`) and thus it is executed
-within a Docker container.
+Run transformations using LLMs. It requires certain dependencies to be present
+(e.g., `openai`) and thus it is executed within a Docker container.
 
 To use this script, you need to provide the input file, output file, and
 the type of transformation to apply.
@@ -35,7 +34,7 @@ def _parse() -> argparse.ArgumentParser:
 
 def _main(parser: argparse.ArgumentParser) -> None:
     args = parser.parse_args()
-    hdbg.init_logger(verbosity=args.log_level, use_exec_path=True)
+    hparser.init_logger_for_input_output_transform(args)
     # Parse files from command line.
     in_file_name, out_file_name = hparser.parse_input_output_args(args)
     # Read file.
@@ -47,7 +46,13 @@ def _main(parser: argparse.ArgumentParser) -> None:
         model = "gpt-4o-mini"
     else:
         model = "gpt-4o"
-    txt_tmp = dshlllpr.run_prompt(prompt_tag, txt_tmp, model, in_file_name, out_file_name)
+    txt_tmp = dshlllpr.run_prompt(
+        prompt_tag,
+        txt_tmp,
+        model,
+        in_file_name=in_file_name,
+        out_file_name=out_file_name,
+    )
     if txt_tmp is not None:
         # Write file, if needed.
         res = []

--- a/dev_scripts_helpers/llms/llm_apply_cfile.py
+++ b/dev_scripts_helpers/llms/llm_apply_cfile.py
@@ -1,45 +1,27 @@
 #!/usr/bin/env python3
 
 """
-Read input from either stdin or a file, apply a specified transformation using
-an LLM, and then write the output to either stdout or a file. It is
-particularly useful for integrating with editors like Vim.
+Read cfile input and implement a transform for each line of the cfile using
+LLMs.
 
-The script `dockerized_llm_transform.py` is executed within a Docker container to ensure
+The script `dockerized_llm_apply_cfile.py` is executed within a Docker container to ensure
 all dependencies are met. The Docker container is built dynamically if
 necessary. The script requires an OpenAI API key to be set in the environment.
 
 Examples
 # Basic Usage
-> llm_transform.py -i input.txt -o output.txt -p uppercase
-
-# List of transforms
-> llm_transform.py -i input.txt -o output.txt -p list
-
-# Code review
-> llm_transform.py -i dev_scripts_helpers/documentation/render_images.py -o cfile -p code_review
-
-# Propose refactoring
-> llm_transform.py -i dev_scripts_helpers/documentation/render_images.py -o cfile -p code_propose_refactoring
+> llm_apply_cfile.py -i cfile.txt
 """
-
-# TODO(gp): There are different modes to run the script
-# - run the script to process input and write transformed output
-# - run the script to process input and extract a cfile
-
 
 import argparse
 import logging
 import os
-import re
 from typing import List, Optional
 
-import dev_scripts_helpers.documentation.lint_notes as dshdlino
 import dev_scripts_helpers.llms.llm_prompts as dshlllpr
 import helpers.hdbg as hdbg
 import helpers.hdocker as hdocker
 import helpers.hgit as hgit
-import helpers.hio as hio
 import helpers.hparser as hparser
 import helpers.hprint as hprint
 import helpers.hserver as hserver
@@ -50,13 +32,18 @@ _LOG = logging.getLogger(__name__)
 
 def _parse() -> argparse.ArgumentParser:
     """
-    Use the same argparse parser for `dockerized_llm_transform.py`.
+    Same interface as `dockerized_llm_apply_cfile.py`.
     """
     parser = argparse.ArgumentParser(
         description=__doc__,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
-    hparser.add_input_output_args(parser)
+    parser.add_argument(
+        "--cfile",
+        type=str,
+        required=True,
+        help="Path to the cfile",
+    )
     hparser.add_prompt_arg(parser)
     hparser.add_dockerized_script_arg(parser)
     # Use CRITICAL to avoid logging anything.
@@ -64,10 +51,9 @@ def _parse() -> argparse.ArgumentParser:
     return parser
 
 
-def _run_dockerized_llm_transform(
+def _run_dockerized_llm_apply_cfile(
     in_file_path: str,
     cmd_opts: List[str],
-    out_file_path: str,
     *,
     return_cmd: bool = False,
     force_rebuild: bool = False,
@@ -88,10 +74,10 @@ def _run_dockerized_llm_transform(
     FROM python:3.12-alpine
 
     # Install Bash.
-    #RUN apk add --no-cache bash
+    RUN apk add --no-cache bash
 
     # Set Bash as the default shell.
-    #SHELL ["/bin/bash", "-c"]
+    SHELL ["/bin/bash", "-c"]
 
     # Install pip packages.
     RUN pip install --upgrade pip
@@ -117,15 +103,6 @@ def _run_dockerized_llm_transform(
         is_caller_host=is_caller_host,
         use_sibling_container_for_callee=use_sibling_container_for_callee,
     )
-    out_file_path = hdocker.convert_caller_to_callee_docker_path(
-        out_file_path,
-        caller_mount_path,
-        callee_mount_path,
-        check_if_exists=False,
-        is_input=False,
-        is_caller_host=is_caller_host,
-        use_sibling_container_for_callee=use_sibling_container_for_callee,
-    )
     helpers_root = hgit.find_helpers_root()
     helpers_root = hdocker.convert_caller_to_callee_docker_path(
         helpers_root,
@@ -137,8 +114,9 @@ def _run_dockerized_llm_transform(
         use_sibling_container_for_callee=use_sibling_container_for_callee,
     )
     git_root = hgit.find_git_root()
+    # TODO(gp): -> llm_apply_cfile.py
     script = hsystem.find_file_in_repo(
-        "dockerized_llm_transform.py", root_dir=git_root
+        "dockerized_llm_apply_cfile.py", root_dir=git_root
     )
     script = hdocker.convert_caller_to_callee_docker_path(
         script,
@@ -150,7 +128,7 @@ def _run_dockerized_llm_transform(
         use_sibling_container_for_callee=use_sibling_container_for_callee,
     )
     cmd_opts_as_str = " ".join(cmd_opts)
-    cmd = f" {script} -i {in_file_path} -o {out_file_path} {cmd_opts_as_str}"
+    cmd = f" {script} --cfile {in_file_path} {cmd_opts_as_str}"
     docker_cmd = hdocker.get_docker_base_cmd(use_sudo)
     docker_cmd.extend(
         [
@@ -171,46 +149,15 @@ def _run_dockerized_llm_transform(
     return ret
 
 
-def _convert_file_names(in_file_name: str, out_file_name: str) -> None:
-    """
-    Convert the files from inside the container to outside.
-
-    Replace the name of the file inside the container (e.g.,
-    `/app/helpers_root/tmp.llm_transform.in.txt`) with the name of the
-    file outside the container.
-    """
-    # TODO(gp): We should use the `convert_caller_to_callee_docker_path`
-    txt_out = []
-    txt = hio.from_file(out_file_name)
-    for line in txt.split("\n"):
-        if line.strip() == "":
-            continue
-        # E.g., the format is like
-        # ```
-        # /app/helpers_root/r.py:1: Change the shebang line to `#!/usr/bin/env python3` to e
-        # ```
-        _LOG.debug("before: %s", hprint.to_str("line in_file_name"))
-        line = re.sub(r"^.*(:\d+:.*)$", rf"{in_file_name}\1", line)
-        _LOG.debug("after: %s", hprint.to_str("line"))
-        txt_out.append(line)
-    txt_out = "\n".join(txt_out)
-    hio.to_file(out_file_name, txt_out)
-
-
 def _main(parser: argparse.ArgumentParser) -> None:
     args = parser.parse_args()
-    hparser.init_logger_for_input_output_transform(args)
+    hdbg.init_logger(
+        verbosity=args.log_level, use_exec_path=True, force_white=False
+    )
     if args.prompt == "list":
         print("# Available prompt tags:")
         print("\n".join(dshlllpr.get_prompt_tags()))
         return
-    # Parse files.
-    in_file_name, out_file_name = hparser.parse_input_output_args(args)
-    tmp_in_file_name, tmp_out_file_name = (
-        hparser.adapt_input_output_args_for_dockerized_scripts(
-            in_file_name, "llm_transform"
-        )
-    )
     # TODO(gp): We should just automatically pass-through the options.
     cmd_line_opts = [f"-p {args.prompt}", f"-v {args.log_level}"]
     if args.fast_model:
@@ -227,35 +174,31 @@ def _main(parser: argparse.ArgumentParser) -> None:
     #         else:
     #             cmd_line_opts.append(f"--{arg.replace('_', '-')} {value}")
     # For stdin/stdout, suppress the output of the container.
-    suppress_output = in_file_name == "-" or out_file_name == "-"
-    _run_dockerized_llm_transform(
-        tmp_in_file_name,
+    suppress_output = False
+    _run_dockerized_llm_apply_cfile(
+        args.cfile,
         cmd_line_opts,
-        tmp_out_file_name,
         return_cmd=False,
         force_rebuild=args.dockerized_force_rebuild,
         use_sudo=args.dockerized_use_sudo,
         suppress_output=suppress_output,
     )
     # Run post-transforms outside the container.
-    # 1) _convert_file_names().
-    prompts = dshlllpr.get_outside_container_post_transforms("convert_file_names")
-    if args.prompt in prompts:
-        _convert_file_names(in_file_name, tmp_out_file_name)
-    # 2) prettier_on_str().
-    out_txt = hio.from_file(tmp_out_file_name)
-    prompts = dshlllpr.get_outside_container_post_transforms("prettier_on_str")
-    if args.prompt in prompts:
-        # Note that we need to run this outside the `llm_transform` container to
-        # avoid to do docker-in-docker in the `llm_transform` container (which
-        # doesn't support that).
-        out_txt = dshdlino.prettier_on_str(out_txt)
+    # # 1) _convert_file_names().
+    # prompts = dshlllpr.get_outside_container_post_transforms("convert_file_names")
+    # if args.prompt in prompts:
+    #     _convert_file_names(in_file_name, tmp_out_file_name)
+    # # 2) prettier_on_str().
+    # out_txt = hio.from_file(tmp_out_file_name)
+    # prompts = dshlllpr.get_outside_container_post_transforms("prettier_on_str")
+    # if args.prompt in prompts:
+    #     # Note that we need to run this outside the `llm_transform` container to
+    #     # avoid to do docker-in-docker in the `llm_transform` container (which
+    #     # doesn't support that).
+    #     out_txt = dshdlino.prettier_on_str(out_txt)
     # Read the output from the container and write it to the output file from
     # command line (e.g., `-` for stdout).
-    hparser.write_file(out_txt, out_file_name)
-    #
-    if os.path.basename(out_file_name) == "cfile":
-        print(out_txt)
+    # hparser.write_file(out_txt, out_file_name)
 
 
 if __name__ == "__main__":

--- a/dev_scripts_helpers/llms/llm_prompts.py
+++ b/dev_scripts_helpers/llms/llm_prompts.py
@@ -4,7 +4,7 @@ import hashlib
 import logging
 import os
 import re
-from typing import List, Optional, Set, Tuple
+from typing import Dict, List, Optional, Set, Tuple
 
 import helpers.hdbg as hdbg
 import helpers.hio as hio
@@ -12,6 +12,11 @@ import helpers.hmarkdown as hmarkdo
 import helpers.hprint as hprint
 
 _LOG = logging.getLogger(__name__)
+
+
+# #############################################################################
+# get_prompt_tags()
+# #############################################################################
 
 
 @functools.lru_cache(maxsize=1)
@@ -46,6 +51,9 @@ def get_prompt_tags() -> List[str]:
     return matched_functions
 
 
+# #############################################################################
+
+
 # Store the prompts that need a certain post-transforms to be applied outside
 # the container.
 OUTSIDE_CONTAINER_POST_TRANSFORMS = {}
@@ -58,10 +66,10 @@ if not OUTSIDE_CONTAINER_POST_TRANSFORMS:
         # These are all the prompts with post_transforms with
         # `convert_to_vim_cfile`.
         "convert_file_names": [
-            "code_review",
-            "code_review_and_find_missing_docstrings",
-            "code_propose_refactoring",
+            "code_review_correctness",
+            "code_review_refactoring",
         ],
+        # remove_code_delimiters
         "prettier_on_str": [
             "md_rewrite",
             "md_summarize_short",
@@ -75,7 +83,7 @@ if not OUTSIDE_CONTAINER_POST_TRANSFORMS:
             hdbg.dassert_in(prompt, valid_prompts)
 
 
-def get_outside_container_post_transforms(transform_name: str) -> Set[str]:
+def get_outside_container_post_transforms(transform_name: str) -> Dict[str, List[str]]:
     hdbg.dassert_in(transform_name, OUTSIDE_CONTAINER_POST_TRANSFORMS.keys())
     return OUTSIDE_CONTAINER_POST_TRANSFORMS[transform_name]
 
@@ -88,111 +96,267 @@ def get_outside_container_post_transforms(transform_name: str) -> Set[str]:
 _PROMPT_OUT = Tuple[str, Set[str], Set[str]]
 
 
+_CONTEXT = r"""
+    You are a proficient Python coder who pays attention to detail.
+    I will pass you a chunk of Python code.
+    """
+
+
 def test() -> _PROMPT_OUT:
     """
-    This is just needed as a placeholder to test the flow.
+    Placeholder to test the flow.
     """
     system = ""
-    pre_transforms = set()
-    post_transforms = set()
+    pre_transforms: Set[str] = set()
+    post_transforms: Set[str] = set()
     return system, pre_transforms, post_transforms
 
 
-_CONTEXT = r"""
-You are a proficient Python coder who pays attention to detail.
-I will pass you a chunk of Python code.
-"""
+# #############################################################################
+# Fix.
+# #############################################################################
 
 
-def code_comment() -> _PROMPT_OUT:
+def code_fix_comments() -> _PROMPT_OUT:
     """
     Add comments to Python code.
     """
     system = _CONTEXT
     system += r"""
-    Every a chunk of 4 or 5 lines of code add comment explaining the code.
-    Comments should go before the logical chunk of code they describe.
-    Comments should be in imperative form, a full English phrase, and end with a
-    period.
+    - Every a chunk of 4 or 5 lines of code add comment explaining the code
+    - Comments should go before the logical chunk of code they describe
+    - Comments should be in imperative form, a full English phrase, and end with a
+      period `.`
+    - Do not comment every single line of code and especially logging statements
     """
-    # You are a proficient Python coder and write English very well.
-    # Given the Python code passed below, improve or add comments to the code.
-    # Comments must be for every logical chunk of 4 or 5 lines of Python code.
-    # Do not comment every single line of code and especially logging statements.
-    # Each comment should be in imperative form, a full English phrase, and end
-    # with a period.
-    pre_transforms = set()
+    pre_transforms: Set[str] = set()
     post_transforms = {"remove_code_delimiters"}
     return system, pre_transforms, post_transforms
 
 
-def code_docstring() -> _PROMPT_OUT:
+def code_fix_docstrings() -> _PROMPT_OUT:
     """
-    Add a REST docstring to Python code.
+    Add or complete a REST docstring to Python code.
+
+    Each function should have a docstring that describes the function,
+    its parameters, and its return value.
     """
     system = _CONTEXT
-    system += r"""
-    Add a docstring to the function passed.
+    system += r'''
+    Make sure each function as a REST docstring
     - The first comment should be in imperative mode and fit in a single line of
-      less than 80 characters.
+      less than 80 characters
     - To describe the parameters use the REST style, which requires each
       parameter to be prepended with :param
-    """
-    pre_transforms = set()
-    post_transforms = {"remove_code_delimiters"}
-    return system, pre_transforms, post_transforms
 
-
-def code_type_hints() -> _PROMPT_OUT:
-    system = _CONTEXT
-    system += r"""
-    You will add type hints to the function passed.
-    """
-    pre_transforms = set()
-    post_transforms = {"remove_code_delimiters"}
-    return system, pre_transforms, post_transforms
-
-
-def _get_code_unit_test_prompt(num_tests: int) -> str:
-    system = _CONTEXT
-    system += r"""
-    You will write a unit test suite for the function passed.
-
-    Write {num_tests} unit tests for the function passed
-    Just output the Python code
-    Use the following style for the unit tests:
-    When calling the function passed assume it's under the module called uut and the user has called `import uut as uut`
+    An example of a correct docstring is:
     ```
-    act = call to the function passed
-    exp = expected code
-    self.assert_equal(act, exp)
+    def _format_greeting(name: str, *, greeting: str = DEFAULT_GREETING) -> str:
+        """
+        Format a greeting message with the given name.
+
+        :param name: the name to include in the greeting
+        :param greeting: the base greeting message to use
+        :return: formatted greeting
+        """
     ```
-    """
-    return system
-
-
-def code_unit_test() -> _PROMPT_OUT:
-    system = _get_code_unit_test_prompt(5)
-    pre_transforms = set()
+    '''
+    pre_transforms: Set[str] = set()
     post_transforms = {"remove_code_delimiters"}
     return system, pre_transforms, post_transforms
 
 
-def code_1_unit_test() -> _PROMPT_OUT:
-    system = _get_code_unit_test_prompt(1)
-    pre_transforms = set()
-    post_transforms = {"remove_code_delimiters"}
-    return system, pre_transforms, post_transforms
-
-
-def code_review() -> _PROMPT_OUT:
+def code_fix_type_hints() -> _PROMPT_OUT:
     system = _CONTEXT
     system += r"""
-    You will review the code and make sure it is correct.
-    You will also make sure that the code is clean and readable.
-    You will also make sure that the code is efficient.
-    You will also make sure that the code is robust.
-    You will also make sure that the code is maintainable.
+    Add type hints to the Python code passed.
+
+    For example, convert:
+    ```
+    def process_data(data, threshold=0.5):
+        results = []
+        for item in data:
+            if item > threshold:
+                results.append(item)
+        return results
+    ```
+    to:
+    ```
+    def process_data(data: List[float], threshold: float = 0.5) -> List[float]:
+        results: List[float] = []
+        for item in data:
+            if item > threshold:
+                results.append(item)
+        return results
+    ```
+    """
+    pre_transforms: Set[str] = set()
+    post_transforms = {"remove_code_delimiters"}
+    return system, pre_transforms, post_transforms
+
+
+def code_fix_log_string() -> _PROMPT_OUT:
+    """
+    Fix the log statements to use % formatting.
+    """
+    system = _CONTEXT
+    system += r"""
+    Fix logging statements and dassert statements by using % formatting instead
+    of f-strings (formatted string literals).
+
+    Do not print any comment, but just the converted code.
+
+    For instance, convert:
+    ```
+    _LOG.info(f"env_var='{str(env_var)}' is not in env_vars='{str(os.environ.keys())}'")
+    ```
+    to
+    ```
+    _LOG.info("env_var='%s' is not in env_vars='%s'", env_var, str(os.environ.keys()))
+    ```
+
+    For instance, convert:
+    ```
+    hdbg.dassert_in(env_var, os.environ, f"env_var='{str(env_var)}' is not in env_vars='{str(os.environ.keys())}''")
+    ```
+    to
+    ```
+    hdbg.dassert_in(env_var, os.environ, "env_var='%s' is not in env_vars='%s'", env_var, str(os.environ.keys()))
+    ```
+    """
+    pre_transforms: Set[str] = set()
+    post_transforms = {"remove_code_delimiters"}
+    return system, pre_transforms, post_transforms
+
+
+def code_fix_by_using_f_strings() -> _PROMPT_OUT:
+    """
+    Fix code to use f-strings, like `f"Hello, {name}.
+
+    You are {age} years old."`.
+    """
+    system = _CONTEXT
+    system += r"""
+    Fix statements like:
+    ```
+    raise ValueError(f"Unsupported data_source='{data_source}'")
+    ```
+    by using f-strings (formatted string literals) instead of % formatting and
+    format strings.
+
+    Do not print any comment, but just the converted code.
+
+    For instance, convert:
+    ```
+    "Hello, %s. You are %d years old." % (name, age)
+    ```
+    to
+    """
+    pre_transforms: Set[str] = set()
+    post_transforms = {"remove_code_delimiters"}
+    return system, pre_transforms, post_transforms
+
+
+def code_fix_by_using_perc_strings() -> _PROMPT_OUT:
+    """
+    Use % formatting, like `"Hello, %s.
+
+    You are %d years old." % (name, age)`.
+    """
+    system = _CONTEXT
+    system += r"""
+    Use % formatting instead of f-strings (formatted string literals).
+
+    Do not print any comment, but just the converted code.
+
+    For instance, convert:
+    to
+    """
+    pre_transforms: Set[str] = set()
+    post_transforms = {"remove_code_delimiters"}
+    return system, pre_transforms, post_transforms
+
+
+def code_fix_from_imports() -> _PROMPT_OUT:
+    """
+    Fix code to use imports instead of "from import" statements.
+    """
+    system = _CONTEXT
+    system += r"""
+    Replace any Python "from import" statement like `from X import Y` with the
+    form `import X` and then replace the uses of `Y` with `X.Y`
+
+    For instance, replace:
+    with:
+    Then replace the uses of `OpenAIEmbeddings` with:
+    """
+    pre_transforms: Set[str] = set()
+    post_transforms = {"remove_code_delimiters"}
+    return system, pre_transforms, post_transforms
+
+
+def code_fix_star_before_optional_parameters() -> _PROMPT_OUT:
+    """
+    Fix code missing the star before optional parameters.
+    """
+    system = _CONTEXT
+    system += r"""
+    When you find a Python function with optional parameters, add a star after
+    the mandatory parameters and before the optional parameters, and make sure
+    that the function is called with the correct number of arguments.
+
+    For instance, replace:
+    with the following:
+    """
+    pre_transforms: Set[str] = set()
+    post_transforms = {"remove_code_delimiters"}
+    return system, pre_transforms, post_transforms
+
+
+def code_fix_csfy_style() -> _PROMPT_OUT:
+    """
+    Apply the csfy style to the code.
+    """
+    # > grep "def code_fix" ./dev_scripts_helpers/llms/llm_prompts.py | awk '{print $2 }'
+    function_names = [
+        "code_fix_comments",
+        "code_fix_docstrings",
+        "code_fix_type_hints",
+        "code_fix_log_string",
+        "code_fix_by_using_f_strings",
+        "code_fix_by_using_perc_strings",
+        "code_fix_from_imports",
+        "code_fix_star_before_optional_parameters",
+    ]
+    system_prompts = []
+    for function_name in function_names:
+        system, pre_transforms_tmp, post_transforms_tmp = eval(function_name)()
+        system_prompts.append(system)
+        hdbg.dassert_eq(pre_transforms_tmp, set())
+        hdbg.dassert_eq(post_transforms_tmp, {"remove_code_delimiters"})
+    system = "\n\n".join(system_prompts)
+    pre_transforms: Set[str] = set()
+    post_transforms = {"remove_code_delimiters"}
+    return system, pre_transforms, post_transforms
+
+
+# #############################################################################
+# Review.
+# #############################################################################
+
+
+def code_review_correctness() -> _PROMPT_OUT:
+    """
+    Review the code for correctness.
+    """
+    system = _CONTEXT
+    system += r"""
+    You will review the code and make sure it is:
+    - correct
+    - clean and readable
+    - efficient
+    - robust
+    - maintainable
 
     Do not print any comment, besides for each point of improvement, you will
     print the line number and the proposed improvement in the following style:
@@ -203,37 +367,10 @@ def code_review() -> _PROMPT_OUT:
     return system, pre_transforms, post_transforms
 
 
-# TODO(gp): This is kind of expensive and we should use a linter stage.
-def code_review_and_find_missing_docstrings() -> _PROMPT_OUT:
+def code_review_refactoring() -> _PROMPT_OUT:
     """
-    Find missing docstrings in Python code.
+    Review the code for refactoring opportunities.
     """
-    system = _CONTEXT
-    system += r"""
-    You will review the code and find missing docstrings.
-
-    Do not print any comment, only print the line number in the following style:
-    <line_number>: <short description of the proposed improvement>
-    """
-    pre_transforms = {"add_line_numbers"}
-    post_transforms = {"convert_to_vim_cfile"}
-    return system, pre_transforms, post_transforms
-
-
-# def code_review_and_fix() -> _PROMPT_OUT:
-#     system = _CONTEXT
-#     system += r"""
-#     You will review the code and make sure it is correct and readable.
-
-#     You will print the code with the proposed improvements, minimizing the
-#     number of changes to the code that are not strictly needed.
-#     """
-#     pre_transforms = {"add_line_numbers"}
-#     post_transforms = {"convert_to_vim_cfile"}
-#     return system, pre_transforms, post_transforms
-
-
-def code_propose_refactoring() -> _PROMPT_OUT:
     system = _CONTEXT
     system += r"""
     You will review the code and look for opportunities to refactor the code,
@@ -248,7 +385,12 @@ def code_propose_refactoring() -> _PROMPT_OUT:
     return system, pre_transforms, post_transforms
 
 
-def code_refactor_and_fix() -> _PROMPT_OUT:
+# #############################################################################
+# Transform the code.
+# #############################################################################
+
+
+def code_transform_remove_redundancy() -> _PROMPT_OUT:
     system = _CONTEXT
     system += r"""
     You will review the code and look for opportunities to refactor the code,
@@ -256,127 +398,86 @@ def code_refactor_and_fix() -> _PROMPT_OUT:
     redundancy in the code, minimizing the number of changes to the code that
     are not needed.
     """
-    pre_transforms = set()
-    post_transforms = set()
+    pre_transforms: Set[str] = set()
+    post_transforms: Set[str] = set()
     return system, pre_transforms, post_transforms
 
 
-def code_apply_linter_issues() -> _PROMPT_OUT:
-    system = _CONTEXT
-    system += r"""
-    I will pass you Python code and a list of linting errors in the format
-    <file_name>:<line_number>:<error_code>:<error_message>
-
-    You will fix the code according to the linting errors passed, minimizing the
-    number of changes to the code that are not needed.
-
-tutorial_github/github_utils.py:105: [W0718(broad-exception-caught), get_github_contributors] Catching too general exception Exception [pylint]
-tutorial_github/github_utils.py:106: [W1203(logging-fstring-interpolation), get_github_contributors] Use lazy % formatting in logging functions [pylint]
+def code_transform_apply_csfy_style() -> _PROMPT_OUT:
     """
-    pre_transforms = set()
-    post_transforms = set()
-    return system, pre_transforms, post_transforms
-
-
-def code_fix_string() -> _PROMPT_OUT:
-    """
-    Fix the log statements to use % formatting.
-    """
-    system = _CONTEXT
-    system += r"""
-    Use % formatting instead of f-strings (formatted string literals).
-    Do not print any comment, just the converted code.
-
-    For instance, convert:
-    _LOG.info(f"env_var='{str(env_var)}' is not in env_vars='{str(os.environ.keys())}'")
-    to
-    _LOG.info("env_var='%s' is not in env_vars='%s'", env_var, str(os.environ.keys()))
-
-    For instance, convert:
-    hdbg.dassert_in(env_var, os.environ, f"env_var='{str(env_var)}' is not in env_vars='{str(os.environ.keys())}''")
-    to
-    hdbg.dassert_in(env_var, os.environ, "env_var='%s' is not in env_vars='%s'", env_var, str(os.environ.keys()))
-    """
-    pre_transforms = set()
-    post_transforms = {"remove_code_delimiters"}
-    return system, pre_transforms, post_transforms
-
-
-def code_use_f_strings() -> _PROMPT_OUT:
-    """
-    Use f-strings, like `f"Hello, {name}. You are {age} years old."`.
-    """
-    system = _CONTEXT
-    system += r"""
-    Use f-strings (formatted string literals) instead of % formatting and format
-    strings. Do not print any comment, just the converted code.
-
-    For instance, convert:
-    "Hello, %s. You are %d years old." % (name, age)
-    to
-    f"Hello, {name}. You are {age} years old."
-    """
-    pre_transforms = set()
-    post_transforms = {"remove_code_delimiters"}
-    return system, pre_transforms, post_transforms
-
-
-def code_use_perc_strings() -> _PROMPT_OUT:
-    """
-    Use % formatting, like `"Hello, %s. You are %d years old." % (name, age)`.
-    """
-    system = _CONTEXT
-    system += r"""
-    Use % formatting instead of f-strings (formatted string literals).
-    Do not print any comment, just the converted code.
-
-    For instance, convert:
-    f"Hello, {name}. You are {age} years old."
-    to
-    "Hello, %s. You are %d years old." % (name, age)
-    """
-    pre_transforms = set()
-    post_transforms = {"remove_code_delimiters"}
-    return system, pre_transforms, post_transforms
-
-
-def code_apply_csfy_style1() -> _PROMPT_OUT:
-    """
-    Apply the csfy style to the code.
+    Apply the style to the code using template code in `template_code.py`.
     """
     system = _CONTEXT
     file_name = "template_code.py"
     file_content = hio.from_file(file_name)
     system += rf"""
-    Apply the style described below to the Python code without changing the
-    behavior of the code.
+    Apply the style described below to the Python code
+    
     ```
     {file_content}
     ```
+    
     Do not remove any code, just format the existing code using the style.
-
-    Do not report any explanation of what you did, just the converted code.
+    Do not change the behavior of the code.
+    Do not report any explanation of what you did, but just the converted code.
     """
-    pre_transforms = set()
+    pre_transforms: Set[str] = set()
     post_transforms = {"remove_code_delimiters"}
     return system, pre_transforms, post_transforms
 
 
-def code_apply_csfy_style2() -> _PROMPT_OUT:
+def code_transform_apply_linter_instructions() -> _PROMPT_OUT:
     """
-    Apply the csfy style to the code.
+    Apply the transforms passed in a cfile to the code.
     """
     system = _CONTEXT
     system += r"""
-    Apply the following style to the code:
-    - Convert docstrings into REST docstrings
-    - Always use imperative in comments
-    - Remove empty spaces in functions
-    - Add type hints, when missing
-    - Use * before mandatory parameters
-    - Make local functions private
-    - Convert .format() to f-string unless it’s a _LOG
+    I will pass you Python code and a list of linting errors in the format
+    <line_number>:<error_code>:<error_message>
+
+    You will fix the code according to the linting errors passed, print the
+    modified code, minimizing the number of changes to the code that are not
+    needed.
+
+    Do not print any discussion, but just the converted code.
     """
+    pre_transforms = {"add_line_numbers", "add_instructions"}
+    post_transforms = {"remove_code_delimiters"}
+    return system, pre_transforms, post_transforms
+
+
+# #############################################################################
+# Unit tests.
+# #############################################################################
+
+
+# TODO(gp): Probably obsolete since Cursor can do it.
+def _get_code_unit_test_prompt(num_tests: int) -> str:
+    system = _CONTEXT
+    system += rf"""
+    - You will write a unit test suite for the function passed.
+
+    - Write {num_tests} unit tests for the function passed
+    - Just output the Python code
+    - Use the following style for the unit tests:
+    - When calling the function passed assume it's under the module called uut
+      and the user has called `import uut as uut`
+    """
+    return system
+
+
+def code_write_unit_test() -> _PROMPT_OUT:
+    system = _get_code_unit_test_prompt(5)
+    pre_transforms: Set[str] = set()
+    post_transforms = {"remove_code_delimiters"}
+    return system, pre_transforms, post_transforms
+
+
+def code_write_1_unit_test() -> _PROMPT_OUT:
+    system = _get_code_unit_test_prompt(1)
+    pre_transforms: Set[str] = set()
+    post_transforms = {"remove_code_delimiters"}
+    return system, pre_transforms, post_transforms
 
 
 # #############################################################################
@@ -386,12 +487,12 @@ def md_rewrite() -> _PROMPT_OUT:
     system = r"""
     You are a proficient technical writer.
 
-    Rewrite the text passed as if you were writing a technical document to increase
-    clarity and readability.
+    Rewrite the text passed as if you were writing a technical document to
+    increase clarity and readability.
     Maintain the structure of the text as much as possible, in terms of bullet
     points and their indentation
     """
-    pre_transforms = set()
+    pre_transforms: Set[str] = set()
     post_transforms = {"remove_code_delimiters"}
     return system, pre_transforms, post_transforms
 
@@ -402,7 +503,7 @@ def md_summarize_short() -> _PROMPT_OUT:
 
     Summarize the text in less than 30 words.
     """
-    pre_transforms = set()
+    pre_transforms: Set[str] = set()
     post_transforms = {"remove_code_delimiters"}
     return system, pre_transforms, post_transforms
 
@@ -418,7 +519,7 @@ def slide_improve() -> _PROMPT_OUT:
     You will convert the following markdown text into bullet points
     Make sure that the text is clean and readable
     """
-    pre_transforms = set()
+    pre_transforms: Set[str] = set()
     post_transforms = {
         "remove_code_delimiters",
         "remove_end_of_line_periods",
@@ -433,18 +534,19 @@ def slide_colorize() -> _PROMPT_OUT:
 
     I will give you markdown text in the next prompt
     - Do not change the text or the structure of the text
-    - You will use multiple colors using pandoc \textcolor{COLOR}{text} to highlight
-    only the most important phrases in the text—those that are key to understanding
-    the main points. Keep the highlights minimal and avoid over-marking. Focus on
-    critical concepts, key data, or essential takeaways rather than full sentences
-    or excessive details.
-    - You can use the following colors in the given order: red, orange, green, teal, cyan, blue, violet, brown
+    - You will use multiple colors using pandoc \textcolor{COLOR}{text} to
+      highlight only the most important phrases in the text—those that are key to
+      understanding the main points. Keep the highlights minimal and avoid
+      over-marking. Focus on critical concepts, key data, or essential takeaways
+      rather than full sentences or excessive details.
+    - You can use the following colors in the given order: red, orange, green,
+      teal, cyan, blue, violet, brown
 
     - You can highlight only 4 words or phrases in the text
 
-    Print only the markdown without any explanation
+    Print only the markdown without any explanation.
     """
-    pre_transforms = set()
+    pre_transforms: Set[str] = set()
     post_transforms = {"remove_code_delimiters"}
     return system, pre_transforms, post_transforms
 
@@ -455,25 +557,45 @@ def slide_colorize_points() -> _PROMPT_OUT:
 
     I will give you markdown text in the next prompt
     - Do not change the text or the structure of the text
-    - You will highlight with \textcolor{COLOR}{text} the bullet point at the first level, without highlighting the - character
-    - You can use the following colors in the given order: red, orange, green, teal, cyan, blue, violet, brown
+    - You will highlight with \textcolor{COLOR}{text} the bullet point at the
+      first level, without highlighting the - character
+    - You can use the following colors in the given order: red, orange, green,
+      teal, cyan, blue, violet, brown
 
-    Print only the markdown without any explanation
+    Print only the markdown without any explanation.
     """
-    pre_transforms = set()
+    pre_transforms: Set[str] = set()
     post_transforms = {"remove_code_delimiters"}
     return system, pre_transforms, post_transforms
 
+
+# #############################################################################
+
+
+def scratch_categorize_topics() -> _PROMPT_OUT:
+    system = r"""
+    For each of the following title of article, find the best topic among the following ones
+
+    LLM Reasoning, Quant Finance, Time Series, Developer Tools, Python Ecosystem, Git and GitHub, Software Architecture, AI Infrastructure, Knowledge Graphs, Diffusion Models, Causal Inference, Trading Strategies, Prompt Engineering, Mathematical Concepts, Dev Productivity, Rust and C++, Marketing and Sales, Probabilistic Programming, Code Refactoring, Open Source
+
+    Only print
+    - the first 3 words of the title
+    - a separator |
+    - the topic
+    and don't print any explanation
+
+    if you don't know the topic, print "unknown"
+    """
+    pre_transforms: Set[str] = set()
+    post_transforms = {"remove_code_delimiters"}
+    return system, pre_transforms, post_transforms
 
 # #############################################################################
 # Transforms.
 # #############################################################################
 
 
-def _convert_to_vim_cfile_str(txt: str, in_file_name: str) -> str:
-    """
-    Convert the text passed to a string representing a vim cfile.
-    """
+def _extract_vim_cfile_lines(txt: str) -> List[Tuple[int, str]]:
     ret_out = []
     for line in txt.split("\n"):
         _LOG.debug(hprint.to_str("line"))
@@ -500,7 +622,7 @@ def _convert_to_vim_cfile_str(txt: str, in_file_name: str) -> str:
             # ```
             regex = re.compile(
                 r"""
-                ^(\d+)-\d+:    # Line number(s) followed by colon
+                ^(\d+)-\d+:         # Line number(s) followed by colon
                 \s*                 # Space
                 (.*)$               # Rest of line
                 """,
@@ -513,9 +635,24 @@ def _convert_to_vim_cfile_str(txt: str, in_file_name: str) -> str:
         else:
             _LOG.warning("Can't parse line: '%s'", line)
             continue
-        ret_out.append(f"{in_file_name}:{line_number}: {description}")
+        ret_out.append((line_number, description))
+    return ret_out
+
+
+def _convert_to_vim_cfile_str(txt: str, in_file_name: str) -> str:
+    """
+    Convert the text passed to a string representing a vim cfile.
+
+    E.g.,
+    become:
+    """
+    ret_out = _extract_vim_cfile_lines(txt)
+    # Append the file name to the description.
+    ret_out2 = []
+    for line_number, description in ret_out:
+        ret_out2.append(f"{in_file_name}:{line_number}: {description}")
     # Save the output.
-    txt_out = "\n".join(ret_out)
+    txt_out = "\n".join(ret_out2)
     return txt_out
 
 
@@ -544,8 +681,10 @@ def _convert_to_vim_cfile(txt: str, in_file_name: str, out_file_name: str) -> st
 # #############################################################################
 
 
-# Apply transforms to the response.
 def _to_run(action: str, transforms: Set[str]) -> bool:
+    """
+    Return True if the action should be run.
+    """
     if action in transforms:
         transforms.remove(action)
         return True
@@ -553,15 +692,30 @@ def _to_run(action: str, transforms: Set[str]) -> bool:
 
 
 def run_prompt(
-    prompt_tag: str, txt: str, model: str, in_file_name: str, out_file_name: str
+    prompt_tag: str,
+    txt: str,
+    model: str,
+    *,
+    instructions: str = "",
+    in_file_name: str = "",
+    out_file_name: str = "",
 ) -> Optional[str]:
     """
     Run the prompt passed and apply the transforms to the response.
+
+    :param prompt_tag: tag of the prompt to run
+    :param txt: text to run the prompt on
+    :param model: model to use
+    :param instructions: instructions to add to the system prompt (e.g.,
+        line numbers and transforms to apply to each file)
+    :param in_file_name: name of the input file (needed only for cfile)
+    :param out_file_name: name of the output file (needed only for
+        cfile)
+    :return: transformed text
     """
-    _LOG.debug(hprint.to_str("prompt_tag model in_file_name out_file_name"))
+    _LOG.debug(hprint.func_signature_to_str())
     # Get the info corresponding to the prompt tag.
     prompt_tags = get_prompt_tags()
-    _LOG.debug(hprint.to_str("prompt_tags"))
     hdbg.dassert_in(prompt_tag, prompt_tags)
     python_cmd = f"{prompt_tag}()"
     system_prompt, pre_transforms, post_transforms = eval(python_cmd)
@@ -569,16 +723,28 @@ def run_prompt(
     hdbg.dassert_isinstance(pre_transforms, set)
     hdbg.dassert_isinstance(post_transforms, set)
     system_prompt = hprint.dedent(system_prompt)
-    # Run pre-transforms.
+    # 1) Run pre-transforms.
     if _to_run("add_line_numbers", pre_transforms):
         txt = hmarkdo.add_line_numbers(txt)
+    if _to_run("add_instructions", pre_transforms):
+        # Add the specific instructions to the system prompt.
+        # E.g.,
+        # The instructions are:
+        # 52: in private function `_parse`:D401: First line should be in imperative mood; try rephrasing (found 'Same') [doc_formatter]
+        # 174: error: Missing return statement  [return] [mypy]
+        # 192: [W1201(logging-not-lazy), _convert_file_names] Use lazy % formatting in logging functions [pylint]
+        system_prompt = hprint.dedent(system_prompt)
+        hdbg.dassert_ne(instructions, "")
+        system_prompt += "\nThe instructions are:\n" + instructions + "\n\n"
     hdbg.dassert_eq(
         len(pre_transforms),
         0,
         "Not all pre_transforms were run: %s",
         pre_transforms,
     )
+    # 2) Run the prompt.
     if prompt_tag == "test":
+        # Compute the hash of the text.
         txt = "\n".join(txt)
         txt_out = hashlib.sha256(txt.encode("utf-8")).hexdigest()
     else:
@@ -588,13 +754,14 @@ def run_prompt(
         # environment.
         import helpers.hopenai as hopenai
 
+        _LOG.debug(hprint.to_str("system_prompt"))
         response = hopenai.get_completion(
             txt, system_prompt=system_prompt, model=model, print_cost=True
         )
         # _LOG.debug(hprint.to_str("response"))
         txt_out = hopenai.response_to_txt(response)
     hdbg.dassert_isinstance(txt_out, str)
-    # Run post-transforms.
+    # 3) Run post-transforms.
     if _to_run("remove_code_delimiters", post_transforms):
         txt_out = hmarkdo.remove_code_delimiters(txt_out)
     if _to_run("remove_end_of_line_periods", post_transforms):
@@ -602,6 +769,8 @@ def run_prompt(
     if _to_run("remove_empty_lines", post_transforms):
         txt_out = hmarkdo.remove_empty_lines(txt_out)
     if _to_run("convert_to_vim_cfile", post_transforms):
+        hdbg.dassert_ne(in_file_name, "")
+        hdbg.dassert_ne(out_file_name, "")
         txt_out = _convert_to_vim_cfile(txt_out, in_file_name, out_file_name)
     hdbg.dassert_eq(
         len(post_transforms),

--- a/dev_scripts_helpers/llms/test/test_llm_apply_cfile.py
+++ b/dev_scripts_helpers/llms/test/test_llm_apply_cfile.py
@@ -1,0 +1,47 @@
+import logging
+
+import pytest
+
+import helpers.hserver as hserver
+import helpers.hunit_test as hunitest
+
+_LOG = logging.getLogger(__name__)
+
+
+# #############################################################################
+# Test_llm_apply_cfile1
+# #############################################################################
+
+
+@pytest.mark.skipif(
+    hserver.is_inside_ci() or hserver.is_dev_csfy(),
+    reason="Disabled because of CmampTask10710",
+)
+class Test_llm_apply_cfile1(hunitest.TestCase):
+    """
+    Run the script `llm_transform.py` in a Docker container.
+    """
+
+    # i lint --files dev_scripts_helpers/llms/llm_prompts.py
+
+    # llm_apply_cfile.py --cfile linter_warnings.txt -p code_apply_linter_instructions -v DEBUG
+
+
+# cmd line='./linters/base.py --files dev_scripts_helpers/llms/llm_prompts.py --num_threads serial'
+# file_paths=1 ['dev_scripts_helpers/llms/llm_prompts.py']
+# actions=25 ['add_python_init_files', 'add_toc_to_notebook', 'fix_md_links', 'lint_md', 'check_md_toc_headers', 'autoflake', 'fix_whitespaces', 'doc_formatter', 'isort', 'class_method_order', 'normalize_imports', 'format_separating_line', 'add_class_frames', 'remove_empty_lines_in_func
+# tion', 'black', 'process_jupytext', 'check_file_size', 'check_filename', 'check_merge_conflict', 'check_import', 'warn_incorrectly_formatted_todo', 'check_md_reference', 'flake8', 'pylint', 'mypy']
+# ////////////////////////////////////////////////////////////////////////////////
+# dev_scripts_helpers/llms/llm_prompts.py:106: in public function `test`:D404: First word of the docstring should not be `This` [doc_formatter]
+# dev_scripts_helpers/llms/llm_prompts.py:110: error: Need type annotation for "pre_transforms" (hint: "pre_transforms: set[<type>] = ...")  [var-annotated] [mypy]
+# dev_scripts_helpers/llms/llm_prompts.py:111: error: Need type annotation for "post_transforms" (hint: "post_transforms: set[<type>] = ...")  [var-annotated] [mypy]
+# dev_scripts_helpers/llms/llm_prompts.py:132: error: Need type annotation for "pre_transforms" (hint: "pre_transforms: set[<type>] = ...")  [var-annotated] [mypy]
+# dev_scripts_helpers/llms/llm_prompts.py:164: error: Need type annotation for "pre_transforms" (hint: "pre_transforms: set[<type>] = ...")  [var-annotated] [mypy]
+# dev_scripts_helpers/llms/llm_prompts.py:193: error: Need type annotation for "pre_transforms" (hint: "pre_transforms: set[<type>] = ...")  [var-annotated] [mypy]
+# dev_scripts_helpers/llms/llm_prompts.py:227: error: Need type annotation for "pre_transforms" (hint: "pre_transforms: set[<type>] = ...")  [var-annotated] [mypy]
+# dev_scripts_helpers/llms/llm_prompts.py:255: error: Need type annotation for "pre_transforms" (hint: "pre_transforms: set[<type>] = ...")  [var-annotated] [mypy]
+# dev_scripts_helpers/llms/llm_prompts.py:275: error: Need type annotation for "pre_transforms" (hint: "pre_transforms: set[<type>] = ...")  [var-annotated] [mypy]
+# dev_scripts_helpers/llms/llm_prompts.py:293: error: Need type annotation for "pre_transforms" (hint: "pre_transforms: set[<type>] = ...")  [var-annotated] [mypy]
+# dev_scripts_helpers/llms/llm_prompts.py:311: error: Need type annotation for "pre_transforms" (hint: "pre_transforms: set[<type>] = ...")  [var-annotated] [mypy]
+# dev_scripts_helpers/llms/llm_prompts.py:390: error: Need type annotation for "pre_transforms" (hint: "pre_transforms: set[<type>] = ...")  [var-annotated] [mypy]
+# dev_scripts_helpers/llms/llm_prompts.py:391: error: Need type annotation for "post_transforms" (hint: "post_transforms: set[<type>] = ...")  [var-annotated] [mypy]

--- a/dev_scripts_helpers/llms/test/test_llm_prompts.py
+++ b/dev_scripts_helpers/llms/test/test_llm_prompts.py
@@ -60,3 +60,69 @@ class Test_prompt_tags1(hunitest.TestCase):
         _LOG.debug(hprint.to_str("prompt_tags"))
         #
         self.assertGreater(len(prompt_tags), 0)
+
+
+# #############################################################################
+# Test_run_prompt1
+# #############################################################################
+
+
+@pytest.mark.skipif(
+    hserver.is_inside_ci() or hserver.is_dev_csfy(),
+    reason="Disabled because of CmampTask10710",
+)
+class Test_run_prompt1(hunitest.TestCase):
+
+    # TODO(gp): Add one tests for each prompt.
+
+    def test_code_fix_from_imports1(self) -> None:
+        prompt_tag = "code_fix_from_imports"
+        txt = """
+        from bs4 import BeautifulSoup
+
+        start_soup = BeautifulSoup(start_response.content, "html.parser")
+        """
+        exp_output = """
+        import bs4
+
+        start_soup = bs4.BeautifulSoup(start_response.content, "html.parser")
+        """
+        self._run_prompt(prompt_tag, txt, exp_output)
+
+    def test_code_fix_star_before_optional_parameters1(self) -> None:
+        prompt_tag = "code_fix_star_before_optional_parameters"
+        txt = """
+        def transform(input: str, value: str, output: Optional[str] = None) -> str:
+            print(f"input={input}, value={value}, output={output}")
+
+        transform("input", "value")
+        transform("input", "value", "output")
+        """
+        exp_output = """
+        def transform(input: str, value: str, *, output: Optional[str] = None) -> str:
+            print(f"input={input}, value={value}, output={output}")
+
+        transform("input", "value")
+        transform("input", "value", output="output")
+        """
+        self._run_prompt(prompt_tag, txt, exp_output)
+
+    def _run_prompt(
+        self, prompt_tag: str, input_txt: str, exp_output: str
+    ) -> None:
+        # Prepare the input.
+        input_txt = hprint.dedent(input_txt)
+        model = "gpt-4o"
+        in_file_name = "test.py"
+        out_file_name = "test.py"
+        # Run the prompt.
+        act_output = dshlllpr.run_prompt(
+            prompt_tag,
+            input_txt,
+            model,
+            in_file_name=in_file_name,
+            out_file_name=out_file_name,
+        )
+        # Check the output.
+        exp_output = hprint.dedent(exp_output)
+        self.assert_equal(act_output, exp_output, fuzzy_match=True)

--- a/dev_scripts_helpers/misc/extract_bounties.py
+++ b/dev_scripts_helpers/misc/extract_bounties.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python
+
+"""
+Given the list of potential bounties.
+
+> curl -L -o output.md "https://docs.google.com/document/d/1xPgQ2tWXQuVWKkGVONjOGd5j14mXSmGeY_4d1_sGzAE/export?format=markdown"
+> grep "## " output.md
+## **Template**
+## **LLMs**
+### **Capture / replay interactions with OpenAI**
+### **Extend hopenai.py using LangChain for Multiple Models**
+### **TO\_FILE: Add progress bar to get\_completion**
+### **Create an evaluation suite to compare LLM prompting and models**
+
+Extract sections from a markdown file and create files based on section hierarchy.
+
+This script processes a markdown file to extract level 2 (##) and level 3 (###) sections,
+then creates files named with the format: level3_section,level2_section.txt
+
+Examples:
+# Process a markdown file and create files in default 'output' directory
+> extract_markdown_sections.py input.md
+
+# Process a markdown file and create files in specified directory
+> extract_markdown_sections.py input.md --dst_dir my_output
+"""
+
+import argparse
+import logging
+import re
+from typing import List, Tuple
+
+import helpers.hdbg as hdbg
+import helpers.hio as hio
+import helpers.hparser as hparser
+import helpers.hsystem as hsystem
+
+_LOG = logging.getLogger(__name__)
+
+
+def _clean_up(line: str) -> str:
+    # Remove the ** and TO\_FILE
+    line = line.replace("**", "").replace("TO\_FILE:", "")
+    # Remove \` and \_.
+    line = line.replace(r"\`", "'").replace(r"\_", "_")
+    #
+    line = line.strip()
+    return line
+
+
+def _extract_sections(markdown_content: str) -> List[Tuple[str, str]]:
+    """
+    Extract sections from markdown content.
+
+    :param markdown_content: string containing the markdown content
+    :return: list of tuples containing (level2_section, level3_section)
+    """
+    sections = []
+    current_level2 = None
+    # Split content into lines
+    lines = markdown_content.split("\n")
+    for line in lines:
+        # Check for level 2 headers (##).
+        level2_match = re.match(r"^##\s+(.+)$", line)
+        if level2_match:
+            current_level2 = level2_match.group(1).strip()
+            current_level2 = _clean_up(current_level2)
+            continue
+        # Check for level 3 headers (###).
+        level3_match = re.match(r"^###\s+(.+)$", line)
+        if level3_match and current_level2:
+            level3_section = level3_match.group(1).strip()
+            level3_section = _clean_up(level3_section)
+            sections.append((current_level2, level3_section))
+    return sections
+
+
+def _parse() -> argparse.ArgumentParser:
+    """
+    Parse command-line arguments.
+
+    :return: argument parser with all command-line arguments
+    """
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument(
+        "--input_file",
+        action="store",
+        required=True,
+        help="Path to the markdown file to process",
+    )
+    parser.add_argument(
+        "--output_file",
+        action="store",
+        required=False,
+        default=None,
+        help="Path to the output file to process",
+    )
+    hparser.add_verbosity_arg(parser)
+    return parser
+
+
+def _main(parser: argparse.ArgumentParser) -> None:
+    """
+    Execute the main logic of the script.
+
+    :param parser: argument parser with command-line arguments
+    """
+    args = parser.parse_args()
+    hdbg.init_logger(verbosity=args.log_level, use_exec_path=True)
+    # Read the input file.
+    content = hio.from_file(args.input_file)
+    # Extract the sections.
+    sections = _extract_sections(content)
+    _LOG.info("Processed %d sections from %s", len(sections), args.input_file)
+    # Convert the list of tuples into a string separated by commas.
+    strs = [f"{level3}\t{level2}" for level2, level3 in sections]
+    txt = "\n".join(strs)
+    # Create a file with the string.
+    if args.output_file:
+        hio.to_file(args.output_file, txt)
+    else:
+        hsystem.to_pbcopy(txt, pbcopy=True)
+
+
+if __name__ == "__main__":
+    _main(_parse())

--- a/dev_scripts_helpers/misc/get_url_titles.py
+++ b/dev_scripts_helpers/misc/get_url_titles.py
@@ -1,0 +1,69 @@
+import requests
+from bs4 import BeautifulSoup
+
+def get_page_title(url):
+    try:
+        response = requests.get(url, timeout=10)
+        response.raise_for_status()
+        soup = BeautifulSoup(response.text, 'html.parser')
+        title_tag = soup.find('title')
+        return title_tag.string.strip() if title_tag else "No <title> tag found"
+    except requests.RequestException as e:
+        return f"Request failed: {e}"
+
+
+import requests
+from html.parser import HTMLParser
+
+class TitleParser(HTMLParser):
+    def __init__(self):
+        super().__init__()
+        self.in_title = False
+        self.title = None
+
+    def handle_starttag(self, tag, attrs):
+        if tag.lower() == 'title':
+            self.in_title = True
+
+    def handle_data(self, data):
+        if self.in_title and self.title is None:
+            self.title = data.strip()
+
+    def handle_endtag(self, tag):
+        if tag.lower() == 'title':
+            self.in_title = False
+
+def get_title_streaming(url):
+    try:
+        with requests.get(url, stream=True, timeout=10) as r:
+            r.raise_for_status()
+            parser = TitleParser()
+            for chunk in r.iter_content(chunk_size=1024, decode_unicode=True):
+                parser.feed(chunk)
+                if parser.title:
+                    break
+            return parser.title if parser.title else "No <title> tag found"
+    except requests.RequestException as e:
+        return f"Request failed: {e}"
+
+
+
+if __name__ == "__main__":
+    # Example list of URLs
+    files = """
+https://news.ycombinator.com/item?id=34336386
+https://news.ycombinator.com/item?id=29671450
+https://news.ycombinator.com/item?id=22778089
+https://news.ycombinator.com/item?id=23331989
+https://news.ycombinator.com/item?id=34801636
+https://news.ycombinator.com/item?id=30371723
+https://news.ycombinator.com/item?id=26953352
+https://news.ycombinator.com/item?id=23209142
+    """
+    url_list = files.split("\n")
+    import time
+    for url in url_list:
+        #title = get_page_title(url)
+        title = get_title_streaming(url)
+        print("%s,%s" % (url, title))
+        time.sleep(2)

--- a/dev_scripts_helpers/system_tools/remove_escape_chars.py
+++ b/dev_scripts_helpers/system_tools/remove_escape_chars.py
@@ -30,8 +30,7 @@ def _parse() -> argparse.ArgumentParser:
 
 def _main(parser: argparse.ArgumentParser) -> None:
     args = parser.parse_args()
-    print("cmd line: %s" % hdbg.get_command_line())
-    hdbg.init_logger(verbosity=args.log_level, use_exec_path=True)
+    hparser.init_logger_for_input_output_transform(args)
     #
     in_file_name, out_file_name = hparser.parse_input_output_args(
         args, clear_screen=False

--- a/dev_scripts_helpers/thin_client/thin_client_utils.py
+++ b/dev_scripts_helpers/thin_client/thin_client_utils.py
@@ -237,8 +237,6 @@ def create_tmux_session(
     script_path: str,
     dir_suffix: str,
     setenv_path: str,
-    # TODO(Juraj): deprecate the var, the behavior is now inferred.
-    has_subrepo: bool,
 ) -> None:
     """
     Creates a new tmux session or attaches to an existing one.
@@ -256,7 +254,6 @@ def create_tmux_session(
     :param script_path: Path to the script file.
     :param dir_suffix: Prefix for the directory and tmux session name.
     :param setenv_path: Path to the shell script for setting up the environment.
-    :param has_subrepo: Flag indicating if the project has a subrepository.
     """
     print(f"##> {script_path}")
     # Parse the args.

--- a/dev_scripts_helpers/thin_client/tmux.py
+++ b/dev_scripts_helpers/thin_client/tmux.py
@@ -5,9 +5,57 @@ Check whether a tmux session exists and, if not, creates it.
 
 import logging
 import os
+import subprocess
 import sys
+from typing import Tuple
 
 _LOG = logging.getLogger(__name__)
+
+
+# We can't use `hsystem` as this is a bootstrapping script.
+def _system_to_string(
+    cmd: str, abort_on_error: bool = True, verbose: bool = False
+) -> Tuple[int, str]:
+    assert isinstance(cmd, str), "Type of '%s' is %s" % (str(cmd), type(cmd))
+    if verbose:
+        print(f"> {cmd}")
+    stdout = subprocess.PIPE
+    stderr = subprocess.STDOUT
+    with subprocess.Popen(
+        cmd, shell=True, executable="/bin/bash", stdout=stdout, stderr=stderr
+    ) as p:
+        output = ""
+        while True:
+            line = p.stdout.readline().decode("utf-8")  # type: ignore
+            if not line:
+                break
+            # print((line.rstrip("\n")))
+            output += line
+        p.stdout.close()  # type: ignore
+        rc = p.wait()
+    if abort_on_error and rc != 0:
+        msg = (
+            "cmd='%s' failed with rc='%s'" % (cmd, rc)
+        ) + "\nOutput of the failing command is:\n%s" % output
+        _LOG.error(msg)
+        sys.exit(-1)
+    return rc, output
+
+
+# We can't use `hgit` as this is a bootstrapping script.
+def _get_git_root_dir() -> str:
+    """
+    Return the absolute path to the outermost Git repository root.
+
+    If inside a Git submodule, this returns the parent (superproject)
+    root. Otherwise, it returns the current repository's root.
+    :return: absolute path to the outermost Git repository root
+    """
+    cmd = "git rev-parse --show-superproject-working-tree --show-toplevel | head -n1"
+    _, git_root_dir = _system_to_string(cmd)
+    git_root_dir = git_root_dir.strip()
+    return git_root_dir
+
 
 # We need to tweak `PYTHONPATH` directly since we are bootstrapping the system.
 sys.path.append("helpers_root/dev_scripts_helpers/thin_client")
@@ -16,13 +64,15 @@ import thin_client_utils as tcu
 sys.path.append("helpers_root/helpers")
 import helpers.repo_config_utils as hrecouti
 
-_HAS_SUBREPO = hrecouti.get_repo_config().use_helpers_as_nested_module()
-_SCRIPT_PATH = os.path.abspath(__file__)
-if _HAS_SUBREPO:
-    # Change the directory to the real directory if we are in a symlink.
-    dir_name = os.path.dirname(os.path.realpath(_SCRIPT_PATH)) + "/../.."
-    # print(dir_name)
-    os.chdir(dir_name)
+# Get the real file path rather than the symlink path.
+current_file_path = os.path.realpath(__file__)
+current_dir = os.path.dirname(current_file_path)
+# Change to the repo directory so that it can find the repo config.
+os.chdir(current_dir)
+
+# Change to the outermost Git repository root.
+git_root_dir = _get_git_root_dir()
+os.chdir(git_root_dir)
 
 if __name__ == "__main__":
     parser = tcu.create_parser(__doc__)
@@ -30,6 +80,5 @@ if __name__ == "__main__":
     setenv_path = os.path.join(
         f"dev_scripts_{dir_suffix}", "thin_client", "setenv.sh"
     )
-    tcu.create_tmux_session(
-        parser, _SCRIPT_PATH, dir_suffix, setenv_path, _HAS_SUBREPO
-    )
+    script_path = os.path.abspath(__file__)
+    tcu.create_tmux_session(parser, script_path, dir_suffix, setenv_path)

--- a/dev_scripts_helpers/update_devops_packages/notebooks/Master_buildmeister_dashboard.ipynb
+++ b/dev_scripts_helpers/update_devops_packages/notebooks/Master_buildmeister_dashboard.ipynb
@@ -1,338 +1,377 @@
 {
- "cells": [
-  {
-   "cell_type": "markdown",
-   "id": "e3103ff3",
-   "metadata": {},
-   "source": [
-    " TODO(Grisha): does it belong to the `devops` dir?"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "9d992fed",
-   "metadata": {},
-   "source": [
-    "# Description"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "3e381a7d",
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2024-02-02T08:02:05.889049Z",
-     "start_time": "2024-02-02T08:02:05.883420Z"
-    }
-   },
-   "source": [
-    "The notebook reports the latest build status for multiple repos."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "982f47f1",
-   "metadata": {},
-   "source": [
-    "# Imports"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "97bbec36",
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2024-02-07T17:59:42.038091Z",
-     "start_time": "2024-02-07T17:59:42.002068Z"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "%load_ext autoreload\n",
-    "%autoreload 2\n",
-    "%matplotlib inline"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "518df056",
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2024-02-07T17:59:42.078514Z",
-     "start_time": "2024-02-07T17:59:42.041301Z"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "import logging\n",
-    "from typing import Dict\n",
-    "\n",
-    "import pandas as pd\n",
-    "from IPython.display import Markdown, display\n",
-    "\n",
-    "import helpers.hdbg as hdbg\n",
-    "import helpers.henv as henv\n",
-    "import helpers.hpandas as hpandas\n",
-    "import helpers.hprint as hprint\n",
-    "import helpers.lib_tasks_gh as hlitagh"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "f0793aa5",
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2024-02-07T17:59:42.268049Z",
-     "start_time": "2024-02-07T17:59:42.081426Z"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "hdbg.init_logger(verbosity=logging.INFO)\n",
-    "_LOG = logging.getLogger(__name__)\n",
-    "_LOG.info(\"%s\", henv.get_system_signature()[0])\n",
-    "hprint.config_notebook()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "93c2d39f",
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2024-02-07T17:59:42.338614Z",
-     "start_time": "2024-02-07T17:59:42.271472Z"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "# Set the display options to print the full table.\n",
-    "pd.set_option(\"display.max_colwidth\", None)\n",
-    "pd.set_option(\"display.max_columns\", None)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "14f379d5",
-   "metadata": {
-    "lines_to_next_cell": 2
-   },
-   "source": [
-    "# Utils"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "1f41a8dd",
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2024-02-07T17:59:42.380319Z",
-     "start_time": "2024-02-07T17:59:42.343492Z"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "def make_clickable(url: str) -> str:\n",
-    "    \"\"\"\n",
-    "    Wrapper to make the URL value clickable.\n",
-    "\n",
-    "    :param url: URL value to convert\n",
-    "    :return: clickable URL link\n",
-    "    \"\"\"\n",
-    "    return f'<a href=\"{url}\" target=\"_blank\">{url}</a>'\n",
-    "\n",
-    "\n",
-    "def color_format(val: str, status_color_mapping: Dict[str, str]) -> str:\n",
-    "    \"\"\"\n",
-    "    Return the color depends on status.\n",
-    "\n",
-    "    :param val: value of the status e.g. `failure`\n",
-    "    :param status_color_mapping: mapping statuses to the colors e.g.:\n",
-    "    ```\n",
-    "    {\n",
-    "       \"success\": \"green\",\n",
-    "       \"failure\": \"red\",\n",
-    "    }\n",
-    "    ```\n",
-    "    \"\"\"\n",
-    "    if val in status_color_mapping:\n",
-    "        color = status_color_mapping[val]\n",
-    "    else:\n",
-    "        color = \"grey\"\n",
-    "    return f\"background-color: {color}\""
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "189f2c75",
-   "metadata": {},
-   "source": [
-    "# GH workflows state"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "865bc9f2",
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2024-02-07T17:59:57.513155Z",
-     "start_time": "2024-02-07T17:59:42.383039Z"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "repo_list = [\n",
-    "    \"cryptokaizen/cmamp\",\n",
-    "    \"cryptokaizen/orange\",\n",
-    "    \"cryptokaizen/lemonade\",\n",
-    "    \"causify-ai/kaizenflow\",\n",
-    "]\n",
-    "workflow_df = hlitagh.gh_get_details_for_all_workflows(repo_list)\n",
-    "# Reorder columns.\n",
-    "columns_order = [\"repo_name\", \"workflow_name\", \"conclusion\", \"url\"]\n",
-    "workflow_df = workflow_df[columns_order]\n",
-    "# Make URL values clickable.\n",
-    "workflow_df[\"url\"] = workflow_df[\"url\"].apply(make_clickable)\n",
-    "_LOG.info(hpandas.df_to_str(workflow_df, log_level=logging.INFO))"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "f7e999ce",
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2024-02-07T17:59:57.585606Z",
-     "start_time": "2024-02-07T17:59:57.515915Z"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "status_color_mapping = {\n",
-    "    \"success\": \"green\",\n",
-    "    \"failure\": \"red\",\n",
-    "}\n",
-    "repos = workflow_df[\"repo_name\"].unique()\n",
-    "display(Markdown(\"## Overall Status\"))\n",
-    "current_timestamp = pd.Timestamp.now(tz=\"America/New_York\")\n",
-    "display(Markdown(f\"**Last run: {current_timestamp}**\"))\n",
-    "for repo in repos:\n",
-    "    # Calculate the overall status.\n",
-    "    repo_df = workflow_df[workflow_df[\"repo_name\"] == repo]\n",
-    "    overall_status = hlitagh.gh_get_overall_build_status_for_repo(repo_df)\n",
-    "    display(Markdown(f\"## {repo}: {overall_status}\"))\n",
-    "    repo_df = repo_df.drop(columns=[\"repo_name\"])\n",
-    "    display(\n",
-    "        repo_df.style.map(\n",
-    "            color_format,\n",
-    "            status_color_mapping=status_color_mapping,\n",
-    "            subset=[\"conclusion\"],\n",
-    "        )\n",
-    "    )"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "a00870a9",
-   "metadata": {},
-   "source": [
-    "# Allure reports"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "36e93fca",
-   "metadata": {},
-   "source": [
-    "- fast tests: http://172.30.2.44/allure_reports/cmamp/fast/latest/index.html\n",
-    "- slow tests: http://172.30.2.44/allure_reports/cmamp/slow/latest/index.html\n",
-    "- superslow tests: http://172.30.2.44/allure_reports/cmamp/superslow/latest/index.html"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "bb8ed505",
-   "metadata": {},
-   "source": [
-    "# Number of open pull requests"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "69dbda1d",
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2024-02-07T17:59:59.309022Z",
-     "start_time": "2024-02-07T17:59:57.588291Z"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "for repo in repo_list:\n",
-    "    number_prs = len(hlitagh.gh_get_open_prs(repo))\n",
-    "    _LOG.info(\"%s: %s\", repo, number_prs)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "ec63cb5e",
-   "metadata": {},
-   "source": [
-    "# Code coverage HTML-page"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "569f9404",
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2024-01-24T14:40:31.379819Z",
-     "start_time": "2024-01-24T14:40:31.327151Z"
-    }
-   },
-   "source": [
-    "http://172.30.2.44/html_coverage/runner_master/"
-   ]
-  }
- ],
- "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
-   "language": "python",
-   "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.12.3"
-  },
-  "toc": {
-   "base_numbering": 1,
-   "nav_menu": {},
-   "number_sections": true,
-   "sideBar": true,
-   "skip_h1_title": false,
-   "title_cell": "Table of Contents",
-   "title_sidebar": "Contents",
-   "toc_cell": false,
-   "toc_position": {},
-   "toc_section_display": true,
-   "toc_window_display": false
-  }
- },
- "nbformat": 4,
- "nbformat_minor": 5
+    "cells": [
+        {
+            "cell_type": "markdown",
+            "metadata": {},
+            "source": [
+                "CONTENTS:\n",
+                "- [Description](#description)\n",
+                "- [Imports](#imports)\n",
+                "- [Utils](#utils)\n",
+                "- [GH workflows state](#gh-workflows-state)\n",
+                "- [Allure reports](#allure-reports)\n",
+                "- [Number of open pull requests](#number-of-open-pull-requests)\n",
+                "- [Code coverage HTML-page](#code-coverage-html-page)\n",
+                "- [Code Coverage Page - CodeCov](#code-coverage-page---codecov)"
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "id": "e3103ff3",
+            "metadata": {},
+            "source": [
+                " TODO(Grisha): does it belong to the `devops` dir?"
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "id": "9d992fed",
+            "metadata": {},
+            "source": [
+                "<a name='description'></a>\n",
+                "# Description"
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "id": "3e381a7d",
+            "metadata": {
+                "ExecuteTime": {
+                    "end_time": "2024-02-02T08:02:05.889049Z",
+                    "start_time": "2024-02-02T08:02:05.883420Z"
+                }
+            },
+            "source": [
+                "The notebook reports the latest build status for multiple repos."
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "id": "982f47f1",
+            "metadata": {},
+            "source": [
+                "<a name='imports'></a>\n",
+                "# Imports"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "id": "97bbec36",
+            "metadata": {
+                "ExecuteTime": {
+                    "end_time": "2024-02-07T17:59:42.038091Z",
+                    "start_time": "2024-02-07T17:59:42.002068Z"
+                }
+            },
+            "outputs": [],
+            "source": [
+                "%load_ext autoreload\n",
+                "%autoreload 2\n",
+                "%matplotlib inline"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "id": "518df056",
+            "metadata": {
+                "ExecuteTime": {
+                    "end_time": "2024-02-07T17:59:42.078514Z",
+                    "start_time": "2024-02-07T17:59:42.041301Z"
+                }
+            },
+            "outputs": [],
+            "source": [
+                "import logging\n",
+                "from typing import Dict\n",
+                "\n",
+                "import pandas as pd\n",
+                "from IPython.display import Markdown, display\n",
+                "\n",
+                "import helpers.hdbg as hdbg\n",
+                "import helpers.henv as henv\n",
+                "import helpers.hpandas as hpandas\n",
+                "import helpers.hprint as hprint\n",
+                "import helpers.lib_tasks_gh as hlitagh\n"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "id": "f0793aa5",
+            "metadata": {
+                "ExecuteTime": {
+                    "end_time": "2024-02-07T17:59:42.268049Z",
+                    "start_time": "2024-02-07T17:59:42.081426Z"
+                }
+            },
+            "outputs": [],
+            "source": [
+                "hdbg.init_logger(verbosity=logging.INFO)\n",
+                "_LOG = logging.getLogger(__name__)\n",
+                "_LOG.info(\"%s\", henv.get_system_signature()[0])\n",
+                "hprint.config_notebook()"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "id": "93c2d39f",
+            "metadata": {
+                "ExecuteTime": {
+                    "end_time": "2024-02-07T17:59:42.338614Z",
+                    "start_time": "2024-02-07T17:59:42.271472Z"
+                }
+            },
+            "outputs": [],
+            "source": [
+                "# Set the display options to print the full table.\n",
+                "pd.set_option(\"display.max_colwidth\", None)\n",
+                "pd.set_option(\"display.max_columns\", None)"
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "id": "14f379d5",
+            "metadata": {
+                "lines_to_next_cell": 2
+            },
+            "source": [
+                "<a name='utils'></a>\n",
+                "# Utils"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "id": "1f41a8dd",
+            "metadata": {
+                "ExecuteTime": {
+                    "end_time": "2024-02-07T17:59:42.380319Z",
+                    "start_time": "2024-02-07T17:59:42.343492Z"
+                }
+            },
+            "outputs": [],
+            "source": [
+                "def make_clickable(url: str) -> str:\n",
+                "    \"\"\"\n",
+                "    Wrapper to make the URL value clickable.\n",
+                "\n",
+                "    :param url: URL value to convert\n",
+                "    :return: clickable URL link\n",
+                "    \"\"\"\n",
+                "    return f'<a href=\"{url}\" target=\"_blank\">{url}</a>'\n",
+                "\n",
+                "\n",
+                "def color_format(val: str, status_color_mapping: Dict[str, str]) -> str:\n",
+                "    \"\"\"\n",
+                "    Return the color depends on status.\n",
+                "\n",
+                "    :param val: value of the status e.g. `failure`\n",
+                "    :param status_color_mapping: mapping statuses to the colors e.g.:\n",
+                "    ```\n",
+                "    {\n",
+                "       \"success\": \"green\",\n",
+                "       \"failure\": \"red\",\n",
+                "    }\n",
+                "    ```\n",
+                "    \"\"\"\n",
+                "    if val in status_color_mapping:\n",
+                "        color = status_color_mapping[val]\n",
+                "    else:\n",
+                "        color = \"grey\"\n",
+                "    return f\"background-color: {color}\""
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "id": "189f2c75",
+            "metadata": {},
+            "source": [
+                "<a name='gh-workflows-state'></a>\n",
+                "# GH workflows state"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "id": "865bc9f2",
+            "metadata": {
+                "ExecuteTime": {
+                    "end_time": "2024-02-07T17:59:57.513155Z",
+                    "start_time": "2024-02-07T17:59:42.383039Z"
+                }
+            },
+            "outputs": [],
+            "source": [
+                "repo_list = [\n",
+                "    \"cryptokaizen/cmamp\",\n",
+                "    \"cryptokaizen/orange\",\n",
+                "    \"cryptokaizen/lemonade\",\n",
+                "    \"causify-ai/kaizenflow\",\n",
+                "]\n",
+                "workflow_df = hlitagh.gh_get_details_for_all_workflows(repo_list)\n",
+                "# Reorder columns.\n",
+                "columns_order = [\"repo_name\", \"workflow_name\", \"conclusion\", \"url\"]\n",
+                "workflow_df = workflow_df[columns_order]\n",
+                "# Make URL values clickable.\n",
+                "workflow_df[\"url\"] = workflow_df[\"url\"].apply(make_clickable)\n",
+                "_LOG.info(hpandas.df_to_str(workflow_df, log_level=logging.INFO))"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "id": "f7e999ce",
+            "metadata": {
+                "ExecuteTime": {
+                    "end_time": "2024-02-07T17:59:57.585606Z",
+                    "start_time": "2024-02-07T17:59:57.515915Z"
+                }
+            },
+            "outputs": [],
+            "source": [
+                "status_color_mapping = {\n",
+                "    \"success\": \"green\",\n",
+                "    \"failure\": \"red\",\n",
+                "}\n",
+                "repos = workflow_df[\"repo_name\"].unique()\n",
+                "display(Markdown(\"## Overall Status\"))\n",
+                "current_timestamp = pd.Timestamp.now(tz=\"America/New_York\")\n",
+                "display(Markdown(f\"**Last run: {current_timestamp}**\"))\n",
+                "for repo in repos:\n",
+                "    # Calculate the overall status.\n",
+                "    repo_df = workflow_df[workflow_df[\"repo_name\"] == repo]\n",
+                "    overall_status = hlitagh.gh_get_overall_build_status_for_repo(repo_df)\n",
+                "    display(Markdown(f\"## {repo}: {overall_status}\"))\n",
+                "    repo_df = repo_df.drop(columns=[\"repo_name\"])\n",
+                "    display(\n",
+                "        repo_df.style.map(\n",
+                "            color_format,\n",
+                "            status_color_mapping=status_color_mapping,\n",
+                "            subset=[\"conclusion\"],\n",
+                "        )\n",
+                "    )"
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "id": "a00870a9",
+            "metadata": {},
+            "source": [
+                "<a name='allure-reports'></a>\n",
+                "# Allure reports"
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "id": "36e93fca",
+            "metadata": {},
+            "source": [
+                "- fast tests: http://172.30.2.44/allure_reports/cmamp/fast/latest/index.html\n",
+                "- slow tests: http://172.30.2.44/allure_reports/cmamp/slow/latest/index.html\n",
+                "- superslow tests: http://172.30.2.44/allure_reports/cmamp/superslow/latest/index.html"
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "id": "bb8ed505",
+            "metadata": {},
+            "source": [
+                "<a name='number-of-open-pull-requests'></a>\n",
+                "# Number of open pull requests"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "id": "69dbda1d",
+            "metadata": {
+                "ExecuteTime": {
+                    "end_time": "2024-02-07T17:59:59.309022Z",
+                    "start_time": "2024-02-07T17:59:57.588291Z"
+                }
+            },
+            "outputs": [],
+            "source": [
+                "for repo in repo_list:\n",
+                "    number_prs = len(hlitagh.gh_get_open_prs(repo))\n",
+                "    _LOG.info(\"%s: %s\", repo, number_prs)"
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "id": "ec63cb5e",
+            "metadata": {},
+            "source": [
+                "<a name='code-coverage-html-page'></a>\n",
+                "# Code coverage HTML-page"
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "id": "569f9404",
+            "metadata": {
+                "ExecuteTime": {
+                    "end_time": "2024-01-24T14:40:31.379819Z",
+                    "start_time": "2024-01-24T14:40:31.327151Z"
+                }
+            },
+            "source": [
+                "http://172.30.2.44/html_coverage/runner_master/"
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "id": "027d1b3d",
+            "metadata": {},
+            "source": [
+                "<a name='code-coverage-page---codecov'></a>\n",
+                "# Code Coverage Page - CodeCov"
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "id": "6c9219e1",
+            "metadata": {},
+            "source": [
+                "- Helpers: https://app.codecov.io/gh/causify-ai/helpers"
+            ]
+        }
+    ],
+    "metadata": {
+        "kernelspec": {
+            "display_name": "Python 3 (ipykernel)",
+            "language": "python",
+            "name": "python3"
+        },
+        "language_info": {
+            "codemirror_mode": {
+                "name": "ipython",
+                "version": 3
+            },
+            "file_extension": ".py",
+            "mimetype": "text/x-python",
+            "name": "python",
+            "nbconvert_exporter": "python",
+            "pygments_lexer": "ipython3",
+            "version": "3.12.3"
+        },
+        "toc": {
+            "base_numbering": 1,
+            "nav_menu": {},
+            "number_sections": true,
+            "sideBar": true,
+            "skip_h1_title": false,
+            "title_cell": "Table of Contents",
+            "title_sidebar": "Contents",
+            "toc_cell": false,
+            "toc_position": {},
+            "toc_section_display": true,
+            "toc_window_display": false
+        }
+    },
+    "nbformat": 4,
+    "nbformat_minor": 5
 }

--- a/dev_scripts_helpers/update_devops_packages/notebooks/Master_buildmeister_dashboard.py
+++ b/dev_scripts_helpers/update_devops_packages/notebooks/Master_buildmeister_dashboard.py
@@ -3,33 +3,40 @@
 #   jupytext:
 #     text_representation:
 #       extension: .py
-#       format_name: percent
-#       format_version: '1.3'
-#       jupytext_version: 1.15.2
+#       format_name: light
+#       format_version: '1.5'
+#       jupytext_version: 1.16.7
 #   kernelspec:
 #     display_name: Python 3 (ipykernel)
 #     language: python
 #     name: python3
 # ---
 
-# %% [markdown]
+# CONTENTS:
+# - [Description](#description)
+# - [Imports](#imports)
+# - [Utils](#utils)
+# - [GH workflows state](#gh-workflows-state)
+# - [Allure reports](#allure-reports)
+# - [Number of open pull requests](#number-of-open-pull-requests)
+# - [Code coverage HTML-page](#code-coverage-html-page)
+# - [Code Coverage Page - CodeCov](#code-coverage-page---codecov)
+
 #  TODO(Grisha): does it belong to the `devops` dir?
 
-# %% [markdown]
+# <a name='description'></a>
 # # Description
 
-# %% [markdown]
 # The notebook reports the latest build status for multiple repos.
 
-# %% [markdown]
+# <a name='imports'></a>
 # # Imports
 
-# %%
 # %load_ext autoreload
 # %autoreload 2
 # %matplotlib inline
 
-# %%
+# +
 import logging
 from typing import Dict
 
@@ -42,22 +49,22 @@ import helpers.hpandas as hpandas
 import helpers.hprint as hprint
 import helpers.lib_tasks_gh as hlitagh
 
-# %%
+# -
+
 hdbg.init_logger(verbosity=logging.INFO)
 _LOG = logging.getLogger(__name__)
 _LOG.info("%s", henv.get_system_signature()[0])
 hprint.config_notebook()
 
-# %%
 # Set the display options to print the full table.
 pd.set_option("display.max_colwidth", None)
 pd.set_option("display.max_columns", None)
 
-# %% [markdown]
+# <a name='utils'></a>
 # # Utils
 
 
-# %%
+# +
 def make_clickable(url: str) -> str:
     """
     Wrapper to make the URL value clickable.
@@ -88,10 +95,11 @@ def color_format(val: str, status_color_mapping: Dict[str, str]) -> str:
     return f"background-color: {color}"
 
 
-# %% [markdown]
+# -
+
+# <a name='gh-workflows-state'></a>
 # # GH workflows state
 
-# %%
 repo_list = [
     "cryptokaizen/cmamp",
     "cryptokaizen/orange",
@@ -106,7 +114,6 @@ workflow_df = workflow_df[columns_order]
 workflow_df["url"] = workflow_df["url"].apply(make_clickable)
 _LOG.info(hpandas.df_to_str(workflow_df, log_level=logging.INFO))
 
-# %%
 status_color_mapping = {
     "success": "green",
     "failure": "red",
@@ -129,24 +136,26 @@ for repo in repos:
         )
     )
 
-# %% [markdown]
+# <a name='allure-reports'></a>
 # # Allure reports
 
-# %% [markdown]
 # - fast tests: http://172.30.2.44/allure_reports/cmamp/fast/latest/index.html
 # - slow tests: http://172.30.2.44/allure_reports/cmamp/slow/latest/index.html
 # - superslow tests: http://172.30.2.44/allure_reports/cmamp/superslow/latest/index.html
 
-# %% [markdown]
+# <a name='number-of-open-pull-requests'></a>
 # # Number of open pull requests
 
-# %%
 for repo in repo_list:
     number_prs = len(hlitagh.gh_get_open_prs(repo))
     _LOG.info("%s: %s", repo, number_prs)
 
-# %% [markdown]
+# <a name='code-coverage-html-page'></a>
 # # Code coverage HTML-page
 
-# %% [markdown]
 # http://172.30.2.44/html_coverage/runner_master/
+
+# <a name='code-coverage-page---codecov'></a>
+# # Code Coverage Page - CodeCov
+
+# - Helpers: https://app.codecov.io/gh/causify-ai/helpers

--- a/docs/work_tools/all.import_check.reference.md
+++ b/docs/work_tools/all.import_check.reference.md
@@ -11,6 +11,13 @@
       * [Run the tool on our codebase -- pre-docker procedure](#run-the-tool-on-our-codebase----pre-docker-procedure)
    * [detect_import_cycles](#detect_import_cycles)
       * [Basic usage](#basic-usage-1)
+  * [i show_deps](#i-show_deps)
+      * [Overview](#overview)
+      * [Command usage](#command-usage)
+      * [Examples](#examples)
+      * [Options](#options)
+      * [Limitations](#limitations)
+      * [Running the tool on our codebase](#running-the-tool-on-our-codebase)
 
 
 
@@ -18,7 +25,10 @@
 
 # show_imports
 
+
 A tool for visualizing dependencies among files and packages.
+
+
 
 ## Basic usage
 
@@ -325,3 +335,192 @@ following output, detecting two import cycles:
 ERROR detect_import_cycles.py _main:73    Cyclic imports detected: (input.subdir2.subdir3.file1, input.subdir2.subdir3.file2)
 ERROR detect_import_cycles.py _main:73    Cyclic imports detected: (input.subdir4.file1, input.subdir4.file2, input.subdir4.file3)
 ```
+
+# i show_deps
+
+## Overview
+
+- Analyzes Python files in a directory for intra-directory import dependencies  
+- Generates:
+  - A text report, or  
+  - A DOT file for visualization  
+- Useful for understanding module relationships within a project  
+- Supports options to:
+  - Limit analysis depth  
+  - Focus on cyclic dependencies  
+
+## Command usage
+
+```bash
+i show_deps [--directory <directory>] [--format <format>] [--output_file <file>] [--max_level <level>] [--show_cycles]
+```
+
+- **Default behavior**: Produces a text report, printed to stdout.
+- **Options**:
+  - `--directory`: Specifies the directory to analyze (default: current directory).
+  - `--format`: Sets the output format (`text` or `dot`, default: `text`).
+  - `--output_file`: Saves the report to a file (default: stdout for text, `dependency_graph.dot` for DOT).
+  - `--max_level`: Limits the directory depth for analysis (e.g., `2` for two levels).
+  - `--show_cycles`: Filters the report to show only cyclic dependencies (default: false).
+
+## Examples
+
+The examples below analyze the `helpers` directory, which contains subdirectories like `notebooks/`.
+
+### Generate a text report
+
+Create a text report of all intra-directory dependencies:
+
+```bash
+>i show_deps --directory helpers --format text > report.txt
+```
+
+Output in `report.txt`:
+
+```text
+helpers/notebooks/gallery_parquet.py imports helpers/hdbg.py, helpers/hio.py
+helpers/hdbg.py has no dependencies
+helpers/hio.py has no dependencies
+...
+```
+
+### Generate a DOT file for visualization
+
+Create a DOT file for visualization:
+
+```bash
+>i show_deps --directory helpers --format dot --output_file dependency_graph.dot
+>dot -Tsvg dependency_graph.dot -o dependency_graph.svg
+>open dependency_graph.svg
+```
+
+For large graphs, use the `neato` layout engine:
+
+```bash
+>neato -Tsvg dependency_graph.dot -o dependency_graph.svg -Goverlap=scale -Gsep=+0.5 -Gepsilon=0.01
+>open dependency_graph.svg
+```
+
+### Limit analysis to a specific directory depth
+
+Restrict analysis to a certain depth with `--max_level` (e.g., `--max_level 2` includes `helpers/notebooks/`, excludes deeper subdirectories):
+
+```bash
+>i show_deps --directory helpers --format text --max_level 2 > report_max_level.txt
+```
+
+Output in `report_max_level.txt`:
+
+```text
+helpers/notebooks/gallery_parquet.py imports helpers/hdbg.py, helpers/hio.py
+helpers/hdbg.py has no dependencies
+helpers/hio.py has no dependencies
+...
+```
+
+Visualize the limited graph:
+
+```bash
+>i show_deps --directory helpers --format dot --output_file dependency_graph.dot --max_level 2
+>neato -Tsvg dependency_graph.dot -o dependency_graph.svg -Goverlap=scale -Gsep=+0.5 -Gepsilon=0.01
+>open dependency_graph.svg
+```
+
+### Focus on cyclic dependencies
+
+Show only cyclic dependencies with `--show_cycles`:
+
+```bash
+>i show_deps --directory helpers --format text --show_cycles > report_cycles.txt
+```
+
+Output in `report_cycles.txt` (if cycles exist):
+
+```text
+helpers/module_d.py imports helpers/module_e.py
+helpers/module_e.py imports helpers/module_d.py
+...
+```
+
+Visualize the cyclic dependencies:
+
+```bash
+>i show_deps --directory helpers --format dot --output_file dependency_graph.dot --show_cycles
+>neato -Tsvg dependency_graph.dot -o dependency_graph.svg -Goverlap=scale -Gsep=+0.5 -Gepsilon=0.01
+>open dependency_graph.svg
+```
+
+## Options
+
+- `--directory <path>`: Directory to analyze (default: `.`).
+- `--format <text|dot>`: Output format (default: `text`).
+- `--output_file <file>`: File to save the report (default: stdout for text, `dependency_graph.dot` for DOT).
+- `--max_level <int>`: Maximum directory depth to analyze (e.g., `2`).
+- `--show_cycles`: Show only cyclic dependencies (e.g., `module_d` importing `module_e` and vice versa).
+
+## Limitations
+
+- Analyzes only intra-directory imports; external imports (e.g., `numpy`) are ignored.
+- Imports must resolve within the directory (e.g., `helpers.hdbg` to `helpers/hdbg.py`).
+- Directories with Python files must be modules (contain `__init__.py`), or a `NotModuleError` is raised.
+
+Example of a valid structure:
+
+```text
+helpers
+├── __init__.py
+├── notebooks
+│   ├── gallery_parquet.py
+│   └── __init__.py
+└── hdbg.py
+```
+
+Example causing `NotModuleError`:
+
+```text
+helpers
+├── __init__.py
+├── notebooks
+│   └── gallery_parquet.py
+└── hdbg.py
+```
+
+```bash
+NotModuleError: The following dirs have to be modules (add `__init__.py`): ['helpers/notebooks']
+```
+
+## Running the tool on our codebase
+
+1. **Activate the `helpers` environment**:
+   From the `helpers` root directory:
+   ```bash
+   poetry shell; export PYTHONPATH=$PYTHONPATH:$(pwd)
+   ```
+
+2. **Generate a dependency report**:
+   Create a text report:
+   ```bash
+   i show_deps --directory helpers --format text > report.txt
+   ```
+   Or create a DOT file for visualization:
+   ```bash
+   i show_deps --directory helpers --format dot --output_file dependency_graph.dot
+   ```
+
+3. **Visualize the graph** (optional):
+   Convert the DOT file to SVG and view:
+   ```bash
+   neato -Tsvg dependency_graph.dot -o dependency_graph.svg -Goverlap=scale -Gsep=+0.5 -Gepsilon=0.01
+   open dependency_graph.svg
+   ```
+
+**Troubleshooting**: If `invoke` fails (e.g., `No idea what '--output_file' is!`), use the fallback script:
+```bash
+python3 ~/src/helpers1/generate_deps.py
+neato -Tsvg dependency_graph.dot -o dependency_graph.svg -Goverlap=scale -Gsep=+0.5 -Gepsilon=0.01
+open dependency_graph.svg
+```
+
+**Tips**: The `generate_deps.py` script applies customizations like filtering nodes with no dependencies and shortening labels (e.g., removing `helpers/` prefix). Adjust Graphviz attributes (`ranksep=2.0`, `nodesep=1.0`, `splines=spline`, `overlap=false`, `fontsize=10`) for better visualization.
+
+**Last review**: 2025-05-01 Ehaab Basil

--- a/docs/work_tools/all.import_check.reference.md
+++ b/docs/work_tools/all.import_check.reference.md
@@ -28,12 +28,12 @@
 
 # show_imports
 
-A tool for visualizing dependencies among files and packages.
+`show_imports.py` is a tool for visualizing dependencies among files and packages.
 
 ## Basic usage
 
 ```bash
->./show_imports.py [flags] <target_directory>
+> show_imports.py [flags] <target_directory>
 ```
 
 The script will produce by default an output `.png` file named

--- a/docs/work_tools/all.import_check.reference.md
+++ b/docs/work_tools/all.import_check.reference.md
@@ -1,34 +1,34 @@
-<!--ts-->
-   * [show_imports](#show_imports)
-      * [Basic usage](#basic-usage)
-      * [Visualize dependencies at a directory level](#visualize-dependencies-at-a-directory-level)
-      * [Visualize external dependencies](#visualize-external-dependencies)
-      * [Visualize level X dependencies](#visualize-level-x-dependencies)
-      * [Visualize cyclic dependencies](#visualize-cyclic-dependencies)
-      * [Pydeps-dependent limitations](#pydeps-dependent-limitations)
-         * [NotModuleError](#notmoduleerror)
-         * [Modules above the target directory](#modules-above-the-target-directory)
-      * [Run the tool on our codebase -- pre-docker procedure](#run-the-tool-on-our-codebase----pre-docker-procedure)
-   * [detect_import_cycles](#detect_import_cycles)
-      * [Basic usage](#basic-usage-1)
-  * [i show_deps](#i-show_deps)
-      * [Overview](#overview)
-      * [Command usage](#command-usage)
-      * [Examples](#examples)
-      * [Options](#options)
-      * [Limitations](#limitations)
-      * [Running the tool on our codebase](#running-the-tool-on-our-codebase)
+<!-- toc -->
 
+- [show_imports](#show_imports)
+  * [Basic usage](#basic-usage)
+  * [Visualize dependencies at a directory level](#visualize-dependencies-at-a-directory-level)
+  * [Visualize external dependencies](#visualize-external-dependencies)
+  * [Visualize level X dependencies](#visualize-level-x-dependencies)
+  * [Visualize cyclic dependencies](#visualize-cyclic-dependencies)
+  * [Pydeps-dependent limitations](#pydeps-dependent-limitations)
+    + [NotModuleError](#notmoduleerror)
+    + [Modules above the target directory](#modules-above-the-target-directory)
+  * [Run the tool on our codebase -- pre-docker procedure](#run-the-tool-on-our-codebase----pre-docker-procedure)
+- [detect_import_cycles](#detect_import_cycles)
+  * [Basic usage](#basic-usage-1)
+- [show_deps](#show_deps)
+  * [Overview](#overview)
+  * [Command usage](#command-usage)
+  * [Examples](#examples)
+    + [Generate a text report](#generate-a-text-report)
+    + [Generate a DOT file for visualization](#generate-a-dot-file-for-visualization)
+    + [Limit analysis to a specific directory depth](#limit-analysis-to-a-specific-directory-depth)
+    + [Focus on cyclic dependencies](#focus-on-cyclic-dependencies)
+  * [Options](#options)
+  * [Limitations](#limitations)
+  * [Running the tool on our codebase](#running-the-tool-on-our-codebase)
 
-
-<!--te-->
+<!-- tocstop -->
 
 # show_imports
 
-
 A tool for visualizing dependencies among files and packages.
-
-
 
 ## Basic usage
 
@@ -336,18 +336,18 @@ ERROR detect_import_cycles.py _main:73    Cyclic imports detected: (input.subdir
 ERROR detect_import_cycles.py _main:73    Cyclic imports detected: (input.subdir4.file1, input.subdir4.file2, input.subdir4.file3)
 ```
 
-# i show_deps
+# show_deps
 
 ## Overview
 
-- Analyzes Python files in a directory for intra-directory import dependencies  
+- Analyzes Python files in a directory for intra-directory import dependencies
 - Generates:
-  - A text report, or  
-  - A DOT file for visualization  
-- Useful for understanding module relationships within a project  
+  - A text report, or
+  - A DOT file for visualization
+- Useful for understanding module relationships within a project
 - Supports options to:
-  - Limit analysis depth  
-  - Focus on cyclic dependencies  
+  - Limit analysis depth
+  - Focus on cyclic dependencies
 
 ## Command usage
 
@@ -357,15 +357,20 @@ i show_deps [--directory <directory>] [--format <format>] [--output_file <file>]
 
 - **Default behavior**: Produces a text report, printed to stdout.
 - **Options**:
-  - `--directory`: Specifies the directory to analyze (default: current directory).
+  - `--directory`: Specifies the directory to analyze (default: current
+    directory).
   - `--format`: Sets the output format (`text` or `dot`, default: `text`).
-  - `--output_file`: Saves the report to a file (default: stdout for text, `dependency_graph.dot` for DOT).
-  - `--max_level`: Limits the directory depth for analysis (e.g., `2` for two levels).
-  - `--show_cycles`: Filters the report to show only cyclic dependencies (default: false).
+  - `--output_file`: Saves the report to a file (default: stdout for text,
+    `dependency_graph.dot` for DOT).
+  - `--max_level`: Limits the directory depth for analysis (e.g., `2` for two
+    levels).
+  - `--show_cycles`: Filters the report to show only cyclic dependencies
+    (default: false).
 
 ## Examples
 
-The examples below analyze the `helpers` directory, which contains subdirectories like `notebooks/`.
+The examples below analyze the `helpers` directory, which contains
+subdirectories like `notebooks/`.
 
 ### Generate a text report
 
@@ -403,7 +408,8 @@ For large graphs, use the `neato` layout engine:
 
 ### Limit analysis to a specific directory depth
 
-Restrict analysis to a certain depth with `--max_level` (e.g., `--max_level 2` includes `helpers/notebooks/`, excludes deeper subdirectories):
+Restrict analysis to a certain depth with `--max_level` (e.g., `--max_level 2`
+includes `helpers/notebooks/`, excludes deeper subdirectories):
 
 ```bash
 >i show_deps --directory helpers --format text --max_level 2 > report_max_level.txt
@@ -454,15 +460,20 @@ Visualize the cyclic dependencies:
 
 - `--directory <path>`: Directory to analyze (default: `.`).
 - `--format <text|dot>`: Output format (default: `text`).
-- `--output_file <file>`: File to save the report (default: stdout for text, `dependency_graph.dot` for DOT).
+- `--output_file <file>`: File to save the report (default: stdout for text,
+  `dependency_graph.dot` for DOT).
 - `--max_level <int>`: Maximum directory depth to analyze (e.g., `2`).
-- `--show_cycles`: Show only cyclic dependencies (e.g., `module_d` importing `module_e` and vice versa).
+- `--show_cycles`: Show only cyclic dependencies (e.g., `module_d` importing
+  `module_e` and vice versa).
 
 ## Limitations
 
-- Analyzes only intra-directory imports; external imports (e.g., `numpy`) are ignored.
-- Imports must resolve within the directory (e.g., `helpers.hdbg` to `helpers/hdbg.py`).
-- Directories with Python files must be modules (contain `__init__.py`), or a `NotModuleError` is raised.
+- Analyzes only intra-directory imports; external imports (e.g., `numpy`) are
+  ignored.
+- Imports must resolve within the directory (e.g., `helpers.hdbg` to
+  [`/helpers/hdbg.py)`](/helpers/hdbg.py)).
+- Directories with Python files must be modules (contain `__init__.py`), or a
+  `NotModuleError` is raised.
 
 Example of a valid structure:
 
@@ -491,36 +502,42 @@ NotModuleError: The following dirs have to be modules (add `__init__.py`): ['hel
 
 ## Running the tool on our codebase
 
-1. **Activate the `helpers` environment**:
-   From the `helpers` root directory:
+1. **Activate the `helpers` environment**: From the `helpers` root directory:
+
    ```bash
    poetry shell; export PYTHONPATH=$PYTHONPATH:$(pwd)
    ```
 
-2. **Generate a dependency report**:
-   Create a text report:
+2. **Generate a dependency report**: Create a text report:
+
    ```bash
    i show_deps --directory helpers --format text > report.txt
    ```
+
    Or create a DOT file for visualization:
+
    ```bash
    i show_deps --directory helpers --format dot --output_file dependency_graph.dot
    ```
 
-3. **Visualize the graph** (optional):
-   Convert the DOT file to SVG and view:
+3. **Visualize the graph** (optional): Convert the DOT file to SVG and view:
    ```bash
    neato -Tsvg dependency_graph.dot -o dependency_graph.svg -Goverlap=scale -Gsep=+0.5 -Gepsilon=0.01
    open dependency_graph.svg
    ```
 
-**Troubleshooting**: If `invoke` fails (e.g., `No idea what '--output_file' is!`), use the fallback script:
+**Troubleshooting**: If `invoke` fails (e.g.,
+`No idea what '--output_file' is!`), use the fallback script:
+
 ```bash
 python3 ~/src/helpers1/generate_deps.py
 neato -Tsvg dependency_graph.dot -o dependency_graph.svg -Goverlap=scale -Gsep=+0.5 -Gepsilon=0.01
 open dependency_graph.svg
 ```
 
-**Tips**: The `generate_deps.py` script applies customizations like filtering nodes with no dependencies and shortening labels (e.g., removing `helpers/` prefix). Adjust Graphviz attributes (`ranksep=2.0`, `nodesep=1.0`, `splines=spline`, `overlap=false`, `fontsize=10`) for better visualization.
+**Tips**: The `generate_deps.py` script applies customizations like filtering
+nodes with no dependencies and shortening labels (e.g., removing `helpers/`
+prefix). Adjust Graphviz attributes (`ranksep=2.0`, `nodesep=1.0`,
+`splines=spline`, `overlap=false`, `fontsize=10`) for better visualization.
 
 **Last review**: 2025-05-01 Ehaab Basil

--- a/docs/work_tools/dev_system/all.dealing_with_missing_dependencies.how_to_guide.md
+++ b/docs/work_tools/dev_system/all.dealing_with_missing_dependencies.how_to_guide.md
@@ -57,7 +57,6 @@
     don't want these installation commands running automatically
   - Example (in a Jupyter Notebook cell)
     ```bash
-    # TODO(heanh): Replace with `install_module_if_not_present`
     !sudo sudo /venv/bin/pip install --quiet somepackage)"
     ```
 

--- a/generate_deps.py
+++ b/generate_deps.py
@@ -1,0 +1,36 @@
+from import_check.dependency_graph import DependencyGraph
+import networkx as nx
+
+# Generate dependency graph for the helpers directory
+graph = DependencyGraph("helpers")
+graph.build_graph()
+
+# Print the text report of dependencies - uncomment if needed to see the text report of dependencies (alt to i show deps)
+# print("Text Report:")
+# print(graph.get_text_report())
+
+# Convert to a NetworkX graph for customization
+nx_graph = graph.graph
+
+# Filter out nodes with no dependencies (in-degree and out-degree both 0)
+nodes_to_remove = [node for node in nx_graph.nodes if nx_graph.in_degree(node) == 0 and nx_graph.out_degree(node) == 0]
+nx_graph.remove_nodes_from(nodes_to_remove)
+print(f"Removed {len(nodes_to_remove)} nodes with no dependencies")
+
+# Shorten node labels by removing the "helpers/" prefix
+for node in nx_graph.nodes:
+    new_label = node.replace("helpers/", "")
+    nx_graph.nodes[node]["label"] = new_label
+
+# Add Graphviz attributes for better layout
+nx_graph.graph["graph"] = {
+    "ranksep": "2.0",  # Increase spacing between ranks
+    "nodesep": "1.0",  # Increase spacing between nodes
+    "splines": "spline",  # Use smooth curves for edges
+    "overlap": "false",  # Avoid overlapping nodes
+    "fontsize": "10",  # Smaller font size for labels
+}
+
+# Write the DOT file with the customized graph
+nx.drawing.nx_pydot.write_dot(nx_graph, "dependency_graph.dot")
+print("Dependency graph written to dependency_graph.dot")

--- a/generate_deps.py
+++ b/generate_deps.py
@@ -1,5 +1,6 @@
-from import_check.dependency_graph import DependencyGraph
 import networkx as nx
+
+from import_check.dependency_graph import DependencyGraph
 
 # Generate dependency graph for the helpers directory
 graph = DependencyGraph("helpers")
@@ -13,7 +14,11 @@ graph.build_graph()
 nx_graph = graph.graph
 
 # Filter out nodes with no dependencies (in-degree and out-degree both 0)
-nodes_to_remove = [node for node in nx_graph.nodes if nx_graph.in_degree(node) == 0 and nx_graph.out_degree(node) == 0]
+nodes_to_remove = [
+    node
+    for node in nx_graph.nodes
+    if nx_graph.in_degree(node) == 0 and nx_graph.out_degree(node) == 0
+]
 nx_graph.remove_nodes_from(nodes_to_remove)
 print(f"Removed {len(nodes_to_remove)} nodes with no dependencies")
 

--- a/helpers/hchatgpt.py
+++ b/helpers/hchatgpt.py
@@ -11,14 +11,11 @@ import sys
 import time
 from typing import Dict, List, Optional
 
+import helpers.henv as henv
 import helpers.hio as hio
 
-try:
-    import openai
-except ImportError:
-    os.system("pip install openai")
-finally:
-    import openai
+henv.install_module_if_not_present("openai")
+import openai
 
 _LOG = logging.getLogger(__name__)
 

--- a/helpers/hdocker.py
+++ b/helpers/hdocker.py
@@ -12,7 +12,7 @@ import os
 import re
 import shlex
 import time
-from typing import Any, Dict, List, Optional, Tuple
+from typing import cast, Any, Dict, List, Optional, Tuple
 
 import helpers.hdbg as hdbg
 import helpers.hgit as hgit
@@ -141,7 +141,7 @@ def get_current_arch() -> str:
     cmd = "uname -m"
     _, current_arch = hsystem.system_to_one_line(cmd)
     _LOG.debug(hprint.to_str("current_arch"))
-    return current_arch
+    return cast(str, current_arch)
 
 
 def _is_compatible_arch(val1: str, val2: str) -> bool:
@@ -1444,7 +1444,7 @@ def dockerized_tikz_to_bitmap(
     """
     _LOG.debug(hprint.func_signature_to_str())
     # Convert tikz file to PDF.
-    latex_cmd_opts = []
+    latex_cmd_opts: List[str] = []
     run_latex_again = False
     file_out = hio.change_file_extension(in_file_path, ".pdf")
     run_basic_latex(

--- a/helpers/henv.py
+++ b/helpers/henv.py
@@ -6,7 +6,7 @@ import helpers.henv as henv
 
 import logging
 import os
-from typing import Any, Dict, List, Tuple, Union
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 import helpers.hdbg as hdbg
 import helpers.hprint as hprint
@@ -59,17 +59,26 @@ def has_module(module: str) -> bool:
     return has_module_
 
 
-def install_module_if_not_present(module: str) -> None:
+def install_module_if_not_present(
+    import_name: str, package_name: Optional[str] = None
+) -> None:
     """
     Install a Python module if it is not already installed.
 
-    :param module: name of the module to install
+    :param import_name: name used to import the module
+    :param package_name: name of the package on PyPI (if different from `import_name`)
     """
-    _has_module = has_module(module)
+    _has_module = has_module(import_name)
     if _has_module:
-        print(f"Module '{module}' is already installed.")
+        print(f"Module '{import_name}' is already installed.")
         return
-    _, output = hsystem.system_to_string(f"sudo /venv/bin/pip install {module}")
+    # Sometime the package name is different from the import name.
+    # e.g., we import using `import dash_bootstrap_components`
+    # but the package name is `dash-bootstrap-components`.
+    package_name = package_name or import_name
+    _, output = hsystem.system_to_string(
+        f"sudo /venv/bin/pip install {package_name}"
+    )
     print(output)
 
 

--- a/helpers/henv.py
+++ b/helpers/henv.py
@@ -59,6 +59,20 @@ def has_module(module: str) -> bool:
     return has_module_
 
 
+def install_module_if_not_present(module: str) -> None:
+    """
+    Install a Python module if it is not already installed.
+
+    :param module: name of the module to install
+    """
+    _has_module = has_module(module)
+    if _has_module:
+        print(f"Module '{module}' is already installed.")
+        return
+    _, output = hsystem.system_to_string(f"sudo /venv/bin/pip install {module}")
+    print(output)
+
+
 # All printing functions should:
 # - Return a string and not a list of strings
 # - Add a newline at the end of the string (i.e., the string should end with

--- a/helpers/hmarkdown.py
+++ b/helpers/hmarkdown.py
@@ -26,17 +26,18 @@ _TRACE = False
 # #############################################################################
 
 
-def is_markdown_line_separator(line: str, min_repeats: int = 3) -> bool:
+def is_markdown_line_separator(line: str, min_repeats: int = 5) -> bool:
     """
     Check if the given line is a Markdown separator.
 
-    This function determines if a line consists of repeated characters (`#`, `/`, `-`, `=`)
-    that would indicate a markdown separator.
+    This function determines if a line consists of repeated characters (`#`,
+    `/`, `-`, `=`) that would indicate a markdown separator.
 
     :param line: the current line of text being processed
-    :param min_repeats: the minimum number of times the characters have to be repeated to be
-        considered a separator, e.g., if `min_repeats` = 2, then `##`, `###`, `//` are
-        considered to be line separators, but `#`, `/` are not
+    :param min_repeats: the minimum number of times the characters have to be
+        repeated to be considered a separator, e.g., if `min_repeats` = 2, then
+        `##`, `###`, `//` are considered to be line separators, but `#`, `/` are
+        not
     :return: true if the line is a separator
     """
     separator_pattern = rf"""
@@ -251,6 +252,9 @@ def remove_code_delimiters(txt: str) -> str:
     # Replace the ```python and ``` delimiters with empty strings.
     txt_out = txt.replace("```python", "").replace("```", "")
     txt_out = txt_out.strip()
+    # Remove the numbers at the beginning of the line, if needed
+    # E.g., `3: """` -> `"""`.
+    txt_out = re.sub(r"(^\d+: )", "", txt_out, flags=re.MULTILINE)
     return txt_out
 
 
@@ -274,7 +278,7 @@ def remove_formatting(txt: str) -> str:
     return txt
 
 
-def fix_chatgpt_output(txt: str) -> str:
+def md_clean_up(txt: str) -> str:
     # Replace \( ... \) math syntax with $ ... $.
     txt = re.sub(r"\\\(\s*(.*?)\s*\\\)", r"$\1$", txt)
     # Replace \[ ... \] math syntax with $$ ... $$, handling multiline equations.
@@ -296,15 +300,13 @@ def fix_chatgpt_output(txt: str) -> str:
     txt = re.sub(r"”", r'"', txt)
     # ’
     txt = re.sub(r"’", r"'", txt)
+    # →
+    txt = re.sub(r"→", r"$\\rightarrow$", txt)
     # Remove empty spaces at beginning / end of Latex equations $...$.
     # E.g., $ \text{Student} $ becomes $\text{Student}$
-    txt = re.sub(r"\$\s+(.*?)\s\$", r"$\1$", txt)
-    return txt
-
-
-def md_clean_up(txt: str) -> str:
+    #txt = re.sub(r"\$\s+(.*?)\s\$", r"$\1$", txt)
     # Remove dot at the end of each line.
-    txt = re.sub(r"\.\s*$", "", txt, flags=re.MULTILINE)
+    #txt = re.sub(r"\.\s*$", "", txt, flags=re.MULTILINE)
     return txt
 
 

--- a/helpers/hparser.py
+++ b/helpers/hparser.py
@@ -367,8 +367,20 @@ def parse_input_output_args(
             os.system("clear")
         _LOG.info(hprint.to_str("in_file_name"))
         _LOG.info(hprint.to_str("out_file_name"))
-
     return in_file_name, out_file_name
+
+    
+def init_logger_for_input_output_transform(args: argparse.Namespace) -> None:
+    verbosity = args.log_level
+    # If the input is stdin, we don't want to print the command line or any
+    # other log messages, unless the user specified a more verbose log level.
+    if args.in_file_name == "-":
+        if args.log_level == "INFO":
+            verbosity = "CRITICAL"
+    else:
+        print("cmd line: %s" % hdbg.get_command_line())
+    hdbg.init_logger(verbosity=verbosity, use_exec_path=True,
+        force_white=False)
 
 
 # TODO(gp): GFI -> from_file for symmetry for hio.

--- a/helpers/hsftp.py
+++ b/helpers/hsftp.py
@@ -3,6 +3,7 @@ Import as:
 
 import helpers.hsftp as hsftp
 """
+
 import logging
 import os
 import subprocess
@@ -10,7 +11,9 @@ import sys
 from io import BytesIO
 from typing import List
 
-subprocess.call(["sudo", "/venv/bin/pip", "install", "pysftp"])
+import helpers.henv as henv
+
+henv.install_module_if_not_present("pysftp")
 
 import pysftp
 
@@ -128,7 +131,6 @@ def get_sftp_connection(hostname: str, secret_name: str) -> pysftp.Connection:
     secret_dict = hsecret.get_secret(secret_name)
     username = secret_dict["username"]
     private_key = secret_dict["private_key"]
-
     # Write the private key to a temporary file
     with open("/tmp/temp_key.pem", "w") as temp_key_file:
         temp_key_file.write(private_key)

--- a/helpers/hunit_test.py
+++ b/helpers/hunit_test.py
@@ -396,7 +396,10 @@ def purify_from_environment(txt: str) -> str:
             pass
     # 2) Remove CSFY_GIT_ROOT_PATH
     val = os.environ.get("CSFY_HOST_GIT_ROOT_PATH")
-    txt = re.sub(val, "$CSFY_HOST_GIT_ROOT_PATH", txt, flags=re.MULTILINE)
+    if val is not None:
+        txt = re.sub(val, "$CSFY_HOST_GIT_ROOT_PATH", txt, flags=re.MULTILINE)
+    else:
+        _LOG.debug("CSFY_HOST_GIT_ROOT_PATH is not set")
     # 3) Replace the path of current working dir with `$PWD`.
     pwd = os.getcwd()
     pattern = re.compile(f"{pwd}{dir_pattern}")

--- a/helpers/lib_tasks_docker.py
+++ b/helpers/lib_tasks_docker.py
@@ -94,6 +94,7 @@ def _get_last_container_id(sudo: bool) -> str:
     # 90897241b31a   eeb33fe1880a   "/bin/sh -c '/bin/bash ...
     _, txt = hsystem.system_to_one_line(cmd)
     # Parse the output: there should be at least one line.
+    
     hdbg.dassert_lte(1, len(txt.split(" ")), "Invalid output='%s'", txt)
     container_id: str = txt.split(" ")[0]
     return container_id

--- a/helpers/lib_tasks_docker.py
+++ b/helpers/lib_tasks_docker.py
@@ -94,7 +94,6 @@ def _get_last_container_id(sudo: bool) -> str:
     # 90897241b31a   eeb33fe1880a   "/bin/sh -c '/bin/bash ...
     _, txt = hsystem.system_to_one_line(cmd)
     # Parse the output: there should be at least one line.
-    
     hdbg.dassert_lte(1, len(txt.split(" ")), "Invalid output='%s'", txt)
     container_id: str = txt.split(" ")[0]
     return container_id

--- a/helpers/lib_tasks_gh.py
+++ b/helpers/lib_tasks_gh.py
@@ -104,7 +104,6 @@ def _get_workflow_table() -> htable.TableType:
     # > gh run list | more
     # completed       success AmpTask1786_Integrate_20230518_2        Fast tests      AmpTask1786_Integrate_20230518_2        pull_request    5027911519      7m17s   10m
     # in_progress             AmpTask1786_Integrate_20230518_2        Slow tests      AmpTask1786_Integrate_20230518_2        pull_request    5027911518      10m9s   10m
-
     # pylint: enable=line-too-long
     # The output is tab separated, so convert it into CSV.
     first_line = txt.split("\n")[0]
@@ -228,7 +227,12 @@ def gh_workflow_list(  # type: ignore
                 cmd = f"gh run view {workload_id} --log-failed >{log_file_name}"
                 hsystem.system(cmd)
                 # Remove non-printable chars.
-                cmd = f"remove_escape_chars.py -i {log_file_name}"
+                # TODO(heanh): Consider adding all the helpers util scripts
+                # to the `PATH` (when inside the container) so we can just use
+                # them without specifying the full path.
+                helpers_root_dir = hgit.find_helpers_root()
+                file_path = f"{helpers_root_dir}/dev_scripts_helpers/system_tools"
+                cmd = f"{file_path}/remove_escape_chars.py -i {log_file_name}"
                 hsystem.system(cmd)
                 print(f"# Log is in '{log_file_name}'")
                 # Run_fast_tests  Run fast tests  2021-12-19T00:19:38.3394316Z FAILED data

--- a/helpers/test/test_hmarkdown.py
+++ b/helpers/test/test_hmarkdown.py
@@ -192,7 +192,7 @@ class Test_is_markdown_line_separator1(hunitest.TestCase):
 
     def test_valid_separator2(self) -> None:
         # Prepare inputs.
-        line = "# ---"
+        line = "# ------"
         # Call function.
         act = hmarkdo.is_markdown_line_separator(line)
         # Check output.
@@ -816,7 +816,7 @@ class Test_colorize_first_level_bullets1(hunitest.TestCase):
 # #############################################################################
 
 
-class Test_fix_chatgpt_output1(hunitest.TestCase):
+class Test_md_clean_up1(hunitest.TestCase):
 
     def test1(self) -> None:
         # Prepare inputs.
@@ -848,7 +848,7 @@ class Test_fix_chatgpt_output1(hunitest.TestCase):
         \]
         """
         txt = hprint.dedent(txt)
-        act = hmarkdo.fix_chatgpt_output(txt)
+        act = hmarkdo.md_clean_up(txt)
         act = hprint.dedent(act)
         exp = r"""
         **States**:
@@ -857,18 +857,25 @@ class Test_fix_chatgpt_output1(hunitest.TestCase):
         - $O = \{\text{Yes}, \text{No}\}$ (umbrella)
 
         ### Initial Probabilities:
-        $$\Pr(\text{Sunny}) = 0.6, \quad \Pr(\text{Rainy}) = 0.4$$### Transition Probabilities:$$
+        $$
+        \Pr(\text{Sunny}) = 0.6, \quad \Pr(\text{Rainy}) = 0.4
+        $$
+
+        ### Transition Probabilities:
+        $$
         \begin{aligned}
         \Pr(\text{Sunny} \to \text{Sunny}) &= 0.7, \quad \Pr(\text{Sunny} \to \text{Rainy}) = 0.3 \\
         \Pr(\text{Rainy} \to \text{Sunny}) &= 0.4, \quad \Pr(\text{Rainy} \to \text{Rainy}) = 0.6
         \end{aligned}
-        $$### Observation (Emission) Probabilities:$$
+        $$
+
+        ### Observation (Emission) Probabilities:
+        $$
         \begin{aligned}
         \Pr(\text{Yes} | \text{Sunny}) &= 0.1, \quad \Pr(\text{No} | \text{Sunny}) = 0.9 \\
         \Pr(\text{Yes} | \text{Rainy}) &= 0.8, \quad \Pr(\text{No} | \text{Rainy}) = 0.2
         \end{aligned}
-        $$
-        """
+        $$"""
         self.assert_equal(act, exp, dedent=True)
 
 

--- a/helpers/test/test_lib_tasks.py
+++ b/helpers/test/test_lib_tasks.py
@@ -67,6 +67,7 @@ class _LibTasksTestCase(hunitest.TestCase):
 # #############################################################################
 
 
+# TODO(gp): Make it public.
 def _build_mock_context_returning_ok() -> invoke.MockContext:
     """
     Build a MockContext catching any command and returning rc=0.
@@ -108,9 +109,6 @@ class _CheckDryRunTestCase(hunitest.TestCase):
         # Check the outcome.
         if check:
             self._check_calls(ctx)
-
-
-# #############################################################################
 
 
 # TODO(gp): We should group the tests by what is tested and not how it's

--- a/helpers/test/test_lib_tasks_docker_release.py
+++ b/helpers/test/test_lib_tasks_docker_release.py
@@ -1,0 +1,184 @@
+import logging
+import unittest.mock as umock
+from typing import List
+
+import helpers.hsystem as hsystem
+import helpers.hunit_test as hunitest
+import helpers.lib_tasks_docker_release as hltadore
+import helpers.test.test_lib_tasks as httestlib
+
+_LOG = logging.getLogger(__name__)
+
+
+def _extract_commands_from_call(calls: List[umock._Call]) -> List[str]:
+    """
+    Extract command strings from a list of mock call arguments.
+
+    Example:
+        calls = [
+            (
+                # args tuple: (context, command)
+                (mock_ctx, "docker build --no-cache image1"),
+                # kwargs dictionary
+                {"pty": True}
+            )
+        ]
+        After extraction:
+        ["docker build --no-cache image1"]
+
+    :param calls: list of mock call objects containing (args, kwargs)
+    :return: list of command strings
+    """
+    # Each mock call is a (args, kwargs) tuple, extract the command string
+    # from args[1] in each call.
+    call_list = [args_[1] for args_, kwargs_ in calls]
+    return call_list
+
+
+# #############################################################################
+# TestDockerBuildLocalImage1
+# #############################################################################
+
+
+class TestDockerBuildLocalImage1(hunitest.TestCase):
+
+    def setUp(self) -> None:
+        """
+        Set up test environment and initialize all necessary mocks.
+        """
+        super().setUp()
+        # Mock system calls.
+        self.system_patcher = umock.patch("helpers.hsystem.system")
+        self.mock_system = self.system_patcher.start()
+        # Mock run.
+        self.run_patcher = umock.patch("helpers.lib_tasks_utils.run")
+        self.mock_run = self.run_patcher.start()
+        # Mock version validation.
+        self.version_patcher = umock.patch(
+            "helpers.lib_tasks_docker.dassert_is_subsequent_version"
+        )
+        self.mock_version = self.version_patcher.start()
+        # Mock docker login.
+        self.docker_login_patcher = umock.patch(
+            "helpers.lib_tasks_docker.docker_login"
+        )
+        self.mock_docker_login = self.docker_login_patcher.start()
+        #
+        self.user = hsystem.get_user_name()
+
+    def tearDown(self) -> None:
+        """
+        Clean up test environment by stopping all mocks after each test case.
+        """
+        self.system_patcher.stop()
+        self.run_patcher.stop()
+        self.version_patcher.stop()
+        self.docker_login_patcher.stop()
+        super().tearDown()
+
+    def test_docker_build_single_arch(self) -> None:
+        """
+        Test building a local Docker image with single architecture.
+
+        This test verifies that the correct sequence of commands is
+        generated for building a local Docker image with single
+        architecture.
+        """
+        # Prepare inputs.
+        mock_ctx = httestlib._build_mock_context_returning_ok()
+        test_version = "1.0.0"
+        test_base_image = "test-registry.com/test-image"
+        # Call tested function.
+        hltadore.docker_build_local_image(
+            mock_ctx,
+            test_version,
+            cache=False,
+            base_image=test_base_image,
+            poetry_mode="update",
+        )
+        actual_cmds = _extract_commands_from_call(self.mock_run.call_args_list)
+        actual_cmds = "\n".join(actual_cmds)
+        # The output is a list of strings, each representing a command.
+        exp = r"""
+        cp -f devops/docker_build/dockerignore.dev .dockerignore
+        tar -czh . | DOCKER_BUILDKIT=0 \
+        time \
+        docker build \
+            --no-cache \
+            --build-arg AM_CONTAINER_VERSION=1.0.0 --build-arg INSTALL_DIND=True --build-arg POETRY_MODE=update --build-arg CLEAN_UP_INSTALLATION=True \
+            --tag test-registry.com/test-image:local-$USER_NAME-1.0.0 \
+            --file devops/docker_build/dev.Dockerfile \
+            -
+        invoke docker_cmd --stage local --version 1.0.0 --cmd 'cp -f /install/poetry.lock.out /install/pip_list.txt .' --skip-pull
+        cp -f poetry.lock.out ./devops/docker_build/poetry.lock
+        cp -f pip_list.txt ./devops/docker_build/pip_list.txt
+        docker image ls test-registry.com/test-image:local-$USER_NAME-1.0.0
+        """
+        # Check output.
+        self.assert_equal(
+            actual_cmds,
+            exp,
+            purify_text=True,
+            fuzzy_match=True,
+            remove_lead_trail_empty_lines=True,
+            dedent=True,
+        )
+
+    def test_docker_build_multi_arch(self) -> None:
+        """
+        Test building a local Docker image with multiple architectures.
+
+        This test verifies that the correct sequence of commands is
+        generated for building a local Docker image with multiple
+        architectures.
+        """
+        # Prepare inputs.
+        mock_ctx = httestlib._build_mock_context_returning_ok()
+        test_version = "1.0.0"
+        test_base_image = "test-registry.com/test-image"
+        test_multi_arch = "linux/amd64,linux/arm64"
+        # Call tested function.
+        hltadore.docker_build_local_image(
+            mock_ctx,
+            test_version,
+            cache=False,
+            base_image=test_base_image,
+            poetry_mode="update",
+            multi_arch=test_multi_arch,
+        )
+        actual_cmds = _extract_commands_from_call(self.mock_run.call_args_list)
+        actual_cmds = "\n".join(actual_cmds)
+        # The output is a list of strings, each representing a command.
+        exp = r"""
+        cp -f devops/docker_build/dockerignore.dev .dockerignore
+        docker buildx create \
+            --name multiarch_builder \
+            --driver docker-container \
+            --bootstrap \
+            && \
+            docker buildx use multiarch_builder
+        tar -czh . | DOCKER_BUILDKIT=0 \
+            time \
+            docker buildx build \
+            --no-cache \
+            --push \
+            --platform linux/amd64,linux/arm64 \
+            --build-arg AM_CONTAINER_VERSION=1.0.0 --build-arg INSTALL_DIND=True --build-arg POETRY_MODE=update --build-arg CLEAN_UP_INSTALLATION=True \
+            --tag test-registry.com/test-image:local-$USER_NAME-1.0.0 \
+            --file devops/docker_build/dev.Dockerfile \
+            -
+        docker pull test-registry.com/test-image:local-$USER_NAME-1.0.0
+        invoke docker_cmd --stage local --version 1.0.0 --cmd 'cp -f /install/poetry.lock.out /install/pip_list.txt .' --skip-pull
+        cp -f poetry.lock.out ./devops/docker_build/poetry.lock
+        cp -f pip_list.txt ./devops/docker_build/pip_list.txt
+        docker image ls test-registry.com/test-image:local-$USER_NAME-1.0.0
+        """
+        # Check output.
+        self.assert_equal(
+            actual_cmds,
+            exp,
+            purify_text=True,
+            fuzzy_match=True,
+            remove_lead_trail_empty_lines=True,
+            dedent=True,
+        )

--- a/import_check/dependency_graph.py
+++ b/import_check/dependency_graph.py
@@ -1,0 +1,194 @@
+# Standard library imports
+import ast
+import logging
+from pathlib import Path
+from typing import Union
+
+# Third-party imports
+import networkx as nx
+from networkx.drawing.nx_pydot import write_dot
+
+
+_LOG = logging.getLogger(__name__)
+
+
+class DependencyGraph:
+    """Generate a dependency graph for intra-directory imports.
+
+    Args:
+        directory (str): Path to the directory to analyze.
+        max_level (int, optional): Max directory depth to analyze (default: None).
+        show_cycles (bool, optional): Show only cyclic dependencies (default: False).
+
+    Attributes:
+        directory (Path): Resolved directory path.
+        graph (nx.DiGraph): Directed graph of dependencies.
+        max_level (int, optional): Max directory depth to analyze.
+        show_cycles (bool): Whether to show only cyclic dependencies.
+    """
+
+    def __init__(self, directory: str, max_level: Union[int, None] = None, show_cycles: bool = False):
+        self.directory = Path(directory).resolve()
+        self.graph = nx.DiGraph()
+        self.max_level = max_level
+        self.show_cycles = show_cycles
+
+    def build_graph(self) -> None:
+        """Build a directed graph of intra-directory dependencies.
+
+        Returns:
+            None
+
+        Raises:
+            SyntaxError: Skipped with a warning if a Python file has a syntax error.
+        """
+        _LOG.info(f"Building dependency graph for {self.directory}")
+        # Calculate the base depth of the directory
+        base_depth = len(self.directory.parts)
+        # Find Python files up to max_level
+        py_files = [
+            path for path in self.directory.rglob("*.py")
+            if self.max_level is None or (len(path.parent.parts) - base_depth) <= self.max_level
+        ]
+        _LOG.info(f"Found Python files: {py_files}")
+        for py_file in py_files:
+            relative_path = py_file.relative_to(self.directory.parent).as_posix()
+            _LOG.info(f"Processing file {py_file}, relative path: {relative_path}")
+            self.graph.add_node(relative_path)
+            try:
+                with open(py_file, "r") as f:
+                    tree = ast.parse(f.read(), filename=str(py_file))
+            except SyntaxError as e:
+                _LOG.warning(f"Skipping {py_file} due to syntax error: {e}")
+                continue
+            for node in ast.walk(tree):
+                if isinstance(node, (ast.Import, ast.ImportFrom)):
+                    # Extract import names based on node type
+                    imports = ([name.name for name in node.names]
+                               if isinstance(node, ast.Import) else [node.module])
+                    for imp in imports:
+                        _LOG.info(f"Found import: {imp}")
+                        imp_path = self._resolve_import(imp, py_file)
+                        if imp_path:
+                            _LOG.info(f"Adding edge: {relative_path} -> {imp_path}")
+                            self.graph.add_edge(relative_path, imp_path)
+                        else:
+                            _LOG.info(f"No edge added for import {imp}")
+
+        # Filter for cyclic dependencies if show_cycles is True
+        if self.show_cycles:
+            self._filter_cycles()
+
+    def _filter_cycles(self) -> None:
+        """Filter the graph to show only nodes and edges in cyclic dependencies.
+
+        Returns:
+            None
+        """
+        # Find strongly connected components (cycles)
+        cycles = list(nx.strongly_connected_components(self.graph))
+        # Keep only components with more than one node (i.e., cycles)
+        cyclic_nodes = set()
+        for component in cycles:
+            if len(component) > 1:
+                cyclic_nodes.update(component)
+
+        # Create a new graph with only cyclic nodes and their edges
+        new_graph = nx.DiGraph()
+        for node in cyclic_nodes:
+            new_graph.add_node(node)
+        for u, v in self.graph.edges():
+            if u in cyclic_nodes and v in cyclic_nodes:
+                new_graph.add_edge(u, v)
+
+        self.graph = new_graph
+        _LOG.info(f"Graph filtered to {len(self.graph.nodes)} nodes and {len(self.graph.edges)} edges in cycles")
+
+    def _resolve_import(self, imp: str, py_file: Path) -> str:
+        """Resolve an import to a file path within the directory.
+
+        Args:
+            imp (str): Import statement (e.g., "module.submodule").
+            py_file (Path): File path where the import is found.
+
+        Returns:
+            str: Relative path to the resolved file, or None if unresolved.
+        """
+        _LOG.info(f"Resolving import '{imp}' for file {py_file}")
+        base_dir = self.directory
+        _LOG.info(f"Base directory: {base_dir}")
+        parts = imp.split(".")
+        current_dir = base_dir
+        dir_name = self.directory.name  # for example, "helpers"
+
+        # Handle imports starting with the directory name
+        if parts[0] == dir_name:
+            # Skip the first part dir,  solve for next 
+            parts = parts[1:]
+            if not parts:
+                # Only if the dir name is given (e.g., "helpers"), check for __init__.py
+                init_path = base_dir / "__init__.py"
+                if init_path.exists():
+                    resolved_path = init_path.relative_to(self.directory.parent).as_posix()
+                    _LOG.info(f"Resolved to: {resolved_path}")
+                    return resolved_path
+                _LOG.info(f"Could not resolve import '{imp}' (directory only)")
+                return None
+
+        for i, module_name in enumerate(parts):
+            # Check for package with __init__.py
+            package_path = current_dir / module_name / "__init__.py"
+            _LOG.info(f"Checking package path: {package_path}")
+            if package_path.exists():
+                # If last part, return the __init__.py path
+                if i == len(parts) - 1: 
+                    resolved_path = package_path.relative_to(self.directory.parent).as_posix()
+                    _LOG.info(f"Resolved to: {resolved_path}")
+                    return resolved_path
+                # else, continue to the next part
+                current_dir = current_dir / module_name
+                continue
+            # Check for a .py file 
+            module_path = current_dir / f"{module_name}.py"
+            _LOG.info(f"Checking module path: {module_path}")
+            if module_path.exists():
+                # If last part, return the .py path 
+                if i == len(parts) - 1:
+                    resolved_path = module_path.relative_to(self.directory.parent).as_posix()
+                    _LOG.info(f"Resolved to: {resolved_path}")
+                    return resolved_path
+                # If notlast part, but is a module, it can't lead further 
+                _LOG.info(f"Could not resolve full import '{imp}' beyond {module_path}")
+                return None
+            # If neither exists, the import cannot be resolved 
+            _LOG.info(f"Could not resolve import '{imp}' at part '{module_name}'")
+            return None
+
+        _LOG.info(f"Could not resolve import '{imp}'")
+        return None
+
+    def get_text_report(self) -> str:
+        """Generate a text report listing each module's dependencies.
+
+        Returns:
+            str: Text report of dependencies, one per line.
+        """
+        report = []
+        for node in self.graph.nodes:
+            dependencies = list(self.graph.successors(node))
+            line = (f"{node} imports {', '.join(dependencies)}" if dependencies
+                    else f"{node} has no dependencies")
+            report.append(line)
+        return "\n".join(report)
+
+    def get_dot_file(self, output_file: str) -> None:
+        """Write the dependency graph to a DOT file.
+
+        Args:
+            output_file (str): Path to the output DOT file.
+
+        Returns:
+            None
+        """
+        write_dot(self.graph, output_file)
+        _LOG.info(f"DOT file written to {output_file}")

--- a/import_check/dependency_graph.py
+++ b/import_check/dependency_graph.py
@@ -8,12 +8,17 @@ from typing import Union
 import networkx as nx
 from networkx.drawing.nx_pydot import write_dot
 
-
 _LOG = logging.getLogger(__name__)
 
 
+# #############################################################################
+# DependencyGraph
+# #############################################################################
+
+
 class DependencyGraph:
-    """Generate a dependency graph for intra-directory imports.
+    """
+    Generate a dependency graph for intra-directory imports.
 
     Args:
         directory (str): Path to the directory to analyze.
@@ -27,14 +32,20 @@ class DependencyGraph:
         show_cycles (bool): Whether to show only cyclic dependencies.
     """
 
-    def __init__(self, directory: str, max_level: Union[int, None] = None, show_cycles: bool = False):
+    def __init__(
+        self,
+        directory: str,
+        max_level: Union[int, None] = None,
+        show_cycles: bool = False,
+    ):
         self.directory = Path(directory).resolve()
         self.graph = nx.DiGraph()
         self.max_level = max_level
         self.show_cycles = show_cycles
 
     def build_graph(self) -> None:
-        """Build a directed graph of intra-directory dependencies.
+        """
+        Build a directed graph of intra-directory dependencies.
 
         Returns:
             None
@@ -47,13 +58,17 @@ class DependencyGraph:
         base_depth = len(self.directory.parts)
         # Find Python files up to max_level
         py_files = [
-            path for path in self.directory.rglob("*.py")
-            if self.max_level is None or (len(path.parent.parts) - base_depth) <= self.max_level
+            path
+            for path in self.directory.rglob("*.py")
+            if self.max_level is None
+            or (len(path.parent.parts) - base_depth) <= self.max_level
         ]
         _LOG.info(f"Found Python files: {py_files}")
         for py_file in py_files:
             relative_path = py_file.relative_to(self.directory.parent).as_posix()
-            _LOG.info(f"Processing file {py_file}, relative path: {relative_path}")
+            _LOG.info(
+                f"Processing file {py_file}, relative path: {relative_path}"
+            )
             self.graph.add_node(relative_path)
             try:
                 with open(py_file, "r") as f:
@@ -64,23 +79,59 @@ class DependencyGraph:
             for node in ast.walk(tree):
                 if isinstance(node, (ast.Import, ast.ImportFrom)):
                     # Extract import names based on node type
-                    imports = ([name.name for name in node.names]
-                               if isinstance(node, ast.Import) else [node.module])
+                    imports = (
+                        [name.name for name in node.names]
+                        if isinstance(node, ast.Import)
+                        else [node.module]
+                    )
                     for imp in imports:
                         _LOG.info(f"Found import: {imp}")
                         imp_path = self._resolve_import(imp, py_file)
                         if imp_path:
-                            _LOG.info(f"Adding edge: {relative_path} -> {imp_path}")
+                            _LOG.info(
+                                f"Adding edge: {relative_path} -> {imp_path}"
+                            )
                             self.graph.add_edge(relative_path, imp_path)
                         else:
                             _LOG.info(f"No edge added for import {imp}")
-
         # Filter for cyclic dependencies if show_cycles is True
         if self.show_cycles:
             self._filter_cycles()
 
+    def get_text_report(self) -> str:
+        """
+        Generate a text report listing each module's dependencies.
+
+        Returns:
+            str: Text report of dependencies, one per line.
+        """
+        report = []
+        for node in self.graph.nodes:
+            dependencies = list(self.graph.successors(node))
+            line = (
+                f"{node} imports {', '.join(dependencies)}"
+                if dependencies
+                else f"{node} has no dependencies"
+            )
+            report.append(line)
+        return "\n".join(report)
+
+    def get_dot_file(self, output_file: str) -> None:
+        """
+        Write the dependency graph to a DOT file.
+
+        Args:
+            output_file (str): Path to the output DOT file.
+
+        Returns:
+            None
+        """
+        write_dot(self.graph, output_file)
+        _LOG.info(f"DOT file written to {output_file}")
+
     def _filter_cycles(self) -> None:
-        """Filter the graph to show only nodes and edges in cyclic dependencies.
+        """
+        Filter the graph to show only nodes and edges in cyclic dependencies.
 
         Returns:
             None
@@ -92,7 +143,6 @@ class DependencyGraph:
         for component in cycles:
             if len(component) > 1:
                 cyclic_nodes.update(component)
-
         # Create a new graph with only cyclic nodes and their edges
         new_graph = nx.DiGraph()
         for node in cyclic_nodes:
@@ -100,12 +150,14 @@ class DependencyGraph:
         for u, v in self.graph.edges():
             if u in cyclic_nodes and v in cyclic_nodes:
                 new_graph.add_edge(u, v)
-
         self.graph = new_graph
-        _LOG.info(f"Graph filtered to {len(self.graph.nodes)} nodes and {len(self.graph.edges)} edges in cycles")
+        _LOG.info(
+            f"Graph filtered to {len(self.graph.nodes)} nodes and {len(self.graph.edges)} edges in cycles"
+        )
 
     def _resolve_import(self, imp: str, py_file: Path) -> str:
-        """Resolve an import to a file path within the directory.
+        """
+        Resolve an import to a file path within the directory.
 
         Args:
             imp (str): Import statement (e.g., "module.submodule").
@@ -120,75 +172,54 @@ class DependencyGraph:
         parts = imp.split(".")
         current_dir = base_dir
         dir_name = self.directory.name  # for example, "helpers"
-
         # Handle imports starting with the directory name
         if parts[0] == dir_name:
-            # Skip the first part dir,  solve for next 
+            # Skip the first part dir,  solve for next
             parts = parts[1:]
             if not parts:
                 # Only if the dir name is given (e.g., "helpers"), check for __init__.py
                 init_path = base_dir / "__init__.py"
                 if init_path.exists():
-                    resolved_path = init_path.relative_to(self.directory.parent).as_posix()
+                    resolved_path = init_path.relative_to(
+                        self.directory.parent
+                    ).as_posix()
                     _LOG.info(f"Resolved to: {resolved_path}")
                     return resolved_path
                 _LOG.info(f"Could not resolve import '{imp}' (directory only)")
                 return None
-
         for i, module_name in enumerate(parts):
             # Check for package with __init__.py
             package_path = current_dir / module_name / "__init__.py"
             _LOG.info(f"Checking package path: {package_path}")
             if package_path.exists():
                 # If last part, return the __init__.py path
-                if i == len(parts) - 1: 
-                    resolved_path = package_path.relative_to(self.directory.parent).as_posix()
+                if i == len(parts) - 1:
+                    resolved_path = package_path.relative_to(
+                        self.directory.parent
+                    ).as_posix()
                     _LOG.info(f"Resolved to: {resolved_path}")
                     return resolved_path
                 # else, continue to the next part
                 current_dir = current_dir / module_name
                 continue
-            # Check for a .py file 
+            # Check for a .py file
             module_path = current_dir / f"{module_name}.py"
             _LOG.info(f"Checking module path: {module_path}")
             if module_path.exists():
-                # If last part, return the .py path 
+                # If last part, return the .py path
                 if i == len(parts) - 1:
-                    resolved_path = module_path.relative_to(self.directory.parent).as_posix()
+                    resolved_path = module_path.relative_to(
+                        self.directory.parent
+                    ).as_posix()
                     _LOG.info(f"Resolved to: {resolved_path}")
                     return resolved_path
-                # If notlast part, but is a module, it can't lead further 
-                _LOG.info(f"Could not resolve full import '{imp}' beyond {module_path}")
+                # If notlast part, but is a module, it can't lead further
+                _LOG.info(
+                    f"Could not resolve full import '{imp}' beyond {module_path}"
+                )
                 return None
-            # If neither exists, the import cannot be resolved 
+            # If neither exists, the import cannot be resolved
             _LOG.info(f"Could not resolve import '{imp}' at part '{module_name}'")
             return None
-
         _LOG.info(f"Could not resolve import '{imp}'")
         return None
-
-    def get_text_report(self) -> str:
-        """Generate a text report listing each module's dependencies.
-
-        Returns:
-            str: Text report of dependencies, one per line.
-        """
-        report = []
-        for node in self.graph.nodes:
-            dependencies = list(self.graph.successors(node))
-            line = (f"{node} imports {', '.join(dependencies)}" if dependencies
-                    else f"{node} has no dependencies")
-            report.append(line)
-        return "\n".join(report)
-
-    def get_dot_file(self, output_file: str) -> None:
-        """Write the dependency graph to a DOT file.
-
-        Args:
-            output_file (str): Path to the output DOT file.
-
-        Returns:
-            None
-        """
-        write_dot(self.graph, output_file)
-        _LOG.info(f"DOT file written to {output_file}")

--- a/import_check/test/test_dependency_graph.py
+++ b/import_check/test/test_dependency_graph.py
@@ -1,0 +1,173 @@
+# Standard library imports
+import os
+import shutil
+from pathlib import Path
+
+# Third-party imports
+import pytest
+
+# Local imports
+from import_check.dependency_graph import DependencyGraph
+
+
+@pytest.fixture
+def test_dir():
+    """Create a temporary directory with test files and clean up after.
+
+    Yields:
+        Path: Path to the temporary directory.
+    """
+    dir_path = Path("test_tmp")
+    dir_path.mkdir(exist_ok=True)
+    # Create test files with specific imports
+    with open(dir_path / "module_a.py", "w") as f:
+        f.write("# No imports\n")
+    with open(dir_path / "module_b.py", "w") as f:
+        f.write("import module_a\n")
+    with open(dir_path / "module_c.py", "w") as f:
+        f.write("import module_b\n")
+    with open(dir_path / "module_d.py", "w") as f:
+        f.write("import module_e\n")
+    with open(dir_path / "module_e.py", "w") as f:
+        f.write("import module_d\n")
+    yield dir_path
+    shutil.rmtree(dir_path, ignore_errors=True)
+
+
+class TestDependencyGraph:
+    def test_no_dependencies(self, test_dir: Path) -> None:
+        """Verify a module with no imports has no dependencies."""
+        graph = DependencyGraph(str(test_dir))
+        graph.build_graph()
+        report = graph.get_text_report()
+        assert f"{test_dir}/module_a.py has no dependencies" in report
+
+    def test_multiple_dependencies(self, test_dir: Path) -> None:
+        """Verify modules with chained dependencies are reported correctly."""
+        graph = DependencyGraph(str(test_dir))
+        graph.build_graph()
+        report = graph.get_text_report()
+        assert f"{test_dir}/module_c.py imports {test_dir}/module_b.py" in report
+        assert f"{test_dir}/module_b.py imports {test_dir}/module_a.py" in report
+
+    def test_circular_dependencies(self, test_dir: Path) -> None:
+        """Verify cyclic dependencies are identified correctly."""
+        graph = DependencyGraph(str(test_dir))
+        graph.build_graph()
+        report = graph.get_text_report()
+        assert f"{test_dir}/module_d.py imports {test_dir}/module_e.py" in report
+        assert f"{test_dir}/module_e.py imports {test_dir}/module_d.py" in report
+
+    def test_dot_output(self, test_dir: Path) -> None:
+        """Verify the DOT file is generated with correct format."""
+        graph = DependencyGraph(str(test_dir))
+        graph.build_graph()
+        output_file = "dependency_graph.dot"
+        graph.get_dot_file(output_file)
+        assert os.path.exists(output_file)
+        with open(output_file, "r") as f:
+            content = f.read()
+        assert "digraph" in content
+
+    def test_syntax_error_handling(self, test_dir: Path) -> None:
+        """Verify syntax errors in files are handled without crashing."""
+        with open(test_dir / "module_invalid.py", "w") as f:
+            f.write("def invalid_syntax()  # Missing colon\n")
+        graph = DependencyGraph(str(test_dir))
+        graph.build_graph()
+        report = graph.get_text_report()
+        assert f"{test_dir}/module_a.py has no dependencies" in report
+
+    def test_import_directory_only(self, test_dir: Path) -> None:
+        """Verify importing only the directory name resolves to __init__.py."""
+        # Create __init__.py in the test directory
+        with open(test_dir / "__init__.py", "w") as f:
+            f.write("")
+        # Create a module that imports the directory name
+        with open(test_dir / "module_f.py", "w") as f:
+            f.write(f"import {test_dir.name}\n")
+        graph = DependencyGraph(str(test_dir))
+        graph.build_graph()
+        report = graph.get_text_report()
+        assert f"{test_dir}/module_f.py imports {test_dir}/__init__.py" in report
+
+    def test_package_only_import(self) -> None:
+        """Verify importing a package with only __init__.py adds a dependency."""
+        package_dir = Path("package_only_tmp")
+        package_dir.mkdir(exist_ok=True)
+        subdir = package_dir / "subpackage"
+        subdir.mkdir(exist_ok=True)
+        with open(subdir / "__init__.py", "w") as f:
+            f.write("")
+        with open(package_dir / "module_b.py", "w") as f:
+            f.write("import subpackage\n")
+        try:
+            graph = DependencyGraph(str(package_dir))
+            graph.build_graph()
+            report = graph.get_text_report()
+            assert f"{package_dir}/module_b.py imports {package_dir}/subpackage/__init__.py" in report
+        finally:
+            shutil.rmtree(package_dir)
+
+    def test_package_import(self) -> None:
+        """Verify nested package imports resolve to __init__.py."""
+        package_dir = Path("package_tmp")
+        package_dir.mkdir(exist_ok=True)
+        subdir = package_dir / "subpackage"
+        subdir.mkdir(exist_ok=True)
+        subsubdir = subdir / "subsubpackage"
+        subsubdir.mkdir(exist_ok=True)
+        module_dir = subsubdir / "module_a"
+        module_dir.mkdir(exist_ok=True)
+        with open(subdir / "__init__.py", "w") as f:
+            f.write("")
+        with open(subsubdir / "__init__.py", "w") as f:
+            f.write("")
+        with open(module_dir / "__init__.py", "w") as f:
+            f.write("")
+        with open(package_dir / "module_b.py", "w") as f:
+            f.write("import subpackage.subsubpackage.module_a\n")
+        try:
+            graph = DependencyGraph(str(package_dir))
+            graph.build_graph()
+            report = graph.get_text_report()
+            assert f"{package_dir}/module_b.py imports {package_dir}/subpackage/subsubpackage/module_a/__init__.py" in report
+        finally:
+            shutil.rmtree(package_dir)
+
+    def test_unresolved_nested_import(self) -> None:
+        """Verify unresolved nested imports result in no dependencies."""
+        package_dir = Path("unresolved_tmp")
+        package_dir.mkdir(exist_ok=True)
+        subdir = package_dir / "subpackage"
+        subdir.mkdir(exist_ok=True)
+        with open(subdir / "__init__.py", "w") as f:
+            f.write("")
+        with open(package_dir / "module_b.py", "w") as f:
+            f.write("import subpackage.subsubpackage.module_a\n")
+        try:
+            graph = DependencyGraph(str(package_dir))
+            graph.build_graph()
+            report = graph.get_text_report()
+            assert f"{package_dir}/module_b.py has no dependencies" in report
+        finally:
+            shutil.rmtree(package_dir)
+
+    def test_show_cycles_filters_cyclic_dependencies(self, test_dir: Path) -> None:
+        """Verify show_cycles=True filters the graph to only cyclic dependencies."""
+        # Create a module with no imports to ensure it's filtered out
+        with open(test_dir / "module_f.py", "w") as f:
+            f.write("# No imports\n")
+
+        # Build the graph with show_cycles=True
+        graph = DependencyGraph(str(test_dir), show_cycles=True)
+        graph.build_graph()
+
+        # Get the text report
+        report = graph.get_text_report()
+
+        # Expected output: Only cyclic dependencies (module_d and module_e) should be shown
+        assert f"{test_dir}/module_d.py imports {test_dir}/module_e.py" in report
+        assert f"{test_dir}/module_e.py imports {test_dir}/module_d.py" in report
+        # Verify that non-cyclic module_f is not in the report
+        assert f"{test_dir}/module_f.py" not in report

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from setuptools import setup, find_packages
+from setuptools import find_packages, setup
 
 setup(
     name="helpers",

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,7 @@
+from setuptools import setup, find_packages
+
+setup(
+    name="helpers",
+    version="0.1",
+    packages=find_packages(),
+)

--- a/tasks.py
+++ b/tasks.py
@@ -92,6 +92,7 @@ from helpers.lib_tasks import (  # isort: skip # noqa: F401  # pylint: disable=u
     pytest_repro,
     run_blank_tests,
     run_coverage_report,
+    run_coverage,
     run_fast_slow_superslow_tests,
     run_fast_slow_tests,
     run_fast_tests,

--- a/tasks.py
+++ b/tasks.py
@@ -1,9 +1,8 @@
 import logging
 import os
 from typing import Any
-from invoke import task 
 
-
+from invoke import task
 
 import helpers.repo_config_utils as hrecouti
 
@@ -136,7 +135,6 @@ except ImportError:
     pass
 from import_check.dependency_graph import DependencyGraph
 
-
 # # TODO(gp): This is due to the coupling between code in linter container and
 # #  the code being linted.
 # try:
@@ -180,8 +178,16 @@ def _run_qa_tests(ctx: Any, stage: str, version: str) -> bool:
 
 
 @task
-def show_deps(c, directory=".", format="text", output_file=None, max_level=None, show_cycles=False):
-    """Generate a dependency report for a specified directory.
+def show_deps(
+    c,
+    directory=".",
+    format="text",
+    output_file=None,
+    max_level=None,
+    show_cycles=False,
+):
+    """
+    Generate a dependency report for a specified directory.
 
     Args:
         c: Invoke context (required by invoke, unused).
@@ -198,10 +204,10 @@ def show_deps(c, directory=".", format="text", output_file=None, max_level=None,
     max_level = int(max_level) if max_level is not None else None
     # Convert show_cycles to bool
     show_cycles = show_cycles in (True, "True", "true", "1")
-
-    graph = DependencyGraph(directory, max_level=max_level, show_cycles=show_cycles)
+    graph = DependencyGraph(
+        directory, max_level=max_level, show_cycles=show_cycles
+    )
     graph.build_graph()
-
     if format == "text":
         report = graph.get_text_report()
         if output_file:
@@ -218,6 +224,7 @@ def show_deps(c, directory=".", format="text", output_file=None, max_level=None,
     else:
         raise ValueError(f"Unsupported format: {format}")
 
+
 default_params = {
     # TODO(Nikola): Remove prefix after everything is cleaned.
     #   Currently there are a lot dependencies on prefix.
@@ -232,5 +239,3 @@ default_params = {
 
 set_default_params(default_params)
 parse_command_line()
-
-


### PR DESCRIPTION
#1 

Added `i show_deps` to analyze intra-directory dependencies in `helpers`, with text/DOT reports, tests (94% coverage), and updated docs.

- Implemented `i show_deps` in `tasks.py` with `max_level` and `show_cycles`

- Added `import_check/dependency_graph.py` for dependency analysis
- Added tests in `import_check/test/test_dependency_graph.py` 

- Created script `generate_deps.py` as a fallback for `invoke` failures

- Updated `docs/work_tools/all.import_check.reference.md` with usage
- Updated `.gitignore` to exclude generated files

- Used `nx.nx_pydot.write_dot`

- Isolated tests due to `ModuleNotFoundError` for `helpers.hdbg` and `helpers.hunit_test` in `conftest.py,` likely due to missing dependencies; used a temporary directory to avoid loading `conftest.py`

- Fixed indentation error in `helpers/lib_tasks_docker.py`

- Fixed `CSFY_ECR_BASE_PATH` issue using `os.environ.get()`

- Created PR in fork due to permission restrictions in causify-ai/helpers

- FYI: @gpsaggese @sonniki @Shaunak01
